### PR TITLE
154 - Adjusts sphinx theme to use the RTD theme if available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+try:
+    import sphinx_rtd_theme
+except ImportError:
+    sphinx_rtd_theme = False
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -91,7 +94,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme' if sphinx_rtd_theme else 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -120,7 +123,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()] if sphinx_rtd_theme else []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
https://pulp.plan.io/issues/154

The new implementation only specifies a html_static_path if the `sphinx_rtd_theme` is available. I don't see any `_static` content in the docs anyway so this shouldn't matter. The docs build normally for me with no CSS errors.