### PR TITLE
Remove the doc and coverage checks from run-tests.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "pypy"
 before_install:
   - "pushd .."
-  - "git clone https://github.com/pulp/pulp.git --branch master"
+  - "git clone https://github.com/pulp/pulp.git --branch 2.5-release"
   - "git clone https://github.com/pulp/nectar.git"
   - "pushd nectar"
   - "git checkout python-nectar-1.1.6-1"
@@ -15,6 +15,8 @@ install:
   # This is needed to build M2Crypto
   - "sudo apt-get install swig"
   - "pip install -r test_requirements.txt"
+  # 2.5 didn't have its dependencies in its setup.py, so we need to install them too
+  - "pip install okaara pymongo iniparse"
   - "pushd .."
   - "python nectar/setup.py develop"
   - "pulp/manage_setup_pys.sh develop"
@@ -23,5 +25,5 @@ install:
   - "sudo mkdir -p /etc/pulp"
   - "sudo touch /etc/pulp/server.conf"
 script:
-  - "./run-tests.py --enable-coverage --cover-min-percentage 100"
+  - "./run-tests.py --enable-coverage"
 after_success: coveralls

--- a/run-tests.py
+++ b/run-tests.py
@@ -5,7 +5,6 @@ import os
 import subprocess
 import sys
 
-from pulp.devel import doc_check
 from pulp.devel.test_runner import run_tests
 
 
@@ -31,9 +30,6 @@ exit_code = subprocess.call(['pep257', '--ignore=' + pep257_fail_ignore_codes])
 
 if exit_code != 0:
     sys.exit(exit_code)
-
-# Ensure that all doc strings are present
-doc_check.recursive_check(PROJECT_DIR)
 
 PACKAGES = [PROJECT_DIR, 'pulp_python', ]
 


### PR DESCRIPTION
doc_check and coverage checking are new in Pulp's master branch, but we want 1.0.0 of the
plugins to work against Pulp 2.5 ideally, or at least 2.6.0. This commit removes the doc_check
and coverage check from run-tests.

Also, 2.5 did not list its dependencies in its setup.py, so this adds them to the .travis.yml
file.

This change must not be propagated to master.