### PR TITLE
Fix import ordering

### DIFF
--- a/plugins/pulp_python/plugins/distributors/steps.py
+++ b/plugins/pulp_python/plugins/distributors/steps.py
@@ -1,6 +1,6 @@
+from gettext import gettext as _
 import logging
 import os
-from gettext import gettext as _
 from xml.etree import cElementTree as ElementTree
 
 from pulp.plugins.util.publish_step import AtomicDirectoryPublishStep, PluginStep

--- a/plugins/pulp_python/plugins/distributors/web.py
+++ b/plugins/pulp_python/plugins/distributors/web.py
@@ -1,7 +1,7 @@
 import copy
+from gettext import gettext as _
 import logging
 import shutil
-from gettext import gettext as _
 
 from pulp.common.config import read_json_config
 from pulp.plugins.distributor import Distributor

--- a/plugins/pulp_python/plugins/importers/importer.py
+++ b/plugins/pulp_python/plugins/importers/importer.py
@@ -1,6 +1,6 @@
+from gettext import gettext as _
 import shutil
 import tempfile
-from gettext import gettext as _
 
 from pulp.plugins.importer import Importer
 from pulp.server.db.model import criteria

--- a/plugins/pulp_python/plugins/importers/sync.py
+++ b/plugins/pulp_python/plugins/importers/sync.py
@@ -1,12 +1,12 @@
 """
 This module contains the necessary means for a necessary means for syncing packages from PyPI.
 """
+from cStringIO import StringIO
+from gettext import gettext as _
 import json
 import logging
 import os
 import shutil
-from cStringIO import StringIO
-from gettext import gettext as _
 from urlparse import urljoin
 
 from nectar import request

--- a/plugins/pulp_python/plugins/models.py
+++ b/plugins/pulp_python/plugins/models.py
@@ -1,7 +1,7 @@
+from gettext import gettext as _
 import hashlib
 import re
 import tarfile
-from gettext import gettext as _
 
 from pulp_python.common import constants
 

--- a/plugins/test/unit/plugins/distributors/test_steps.py
+++ b/plugins/test/unit/plugins/distributors/test_steps.py
@@ -1,10 +1,10 @@
 """
 This module contains tests for the pulp_python.plugins.distributors.steps module.
 """
+from gettext import gettext as _
 import os
 import unittest
 
-from gettext import gettext as _
 from xml.etree import cElementTree as ElementTree
 
 import mock

--- a/plugins/test/unit/plugins/importers/test_importer.py
+++ b/plugins/test/unit/plugins/importers/test_importer.py
@@ -1,8 +1,8 @@
 """
 Contains tests for pulp_python.plugins.importers.importer.
 """
-import unittest
 from gettext import gettext as _
+import unittest
 
 import mock
 

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -1,11 +1,11 @@
 """
 This module contains tests for the pulp_python.plugins.importers.sync module.
 """
+from cStringIO import StringIO
+from gettext import gettext as _
 import os
 import types
 import unittest
-from cStringIO import StringIO
-from gettext import gettext as _
 
 import mock
 from pulp.server.db.model import criteria

--- a/plugins/test/unit/plugins/test_models.py
+++ b/plugins/test/unit/plugins/test_models.py
@@ -1,10 +1,10 @@
 """
 This modules contains tests for pulp_python.plugins.models.
 """
+from gettext import gettext as _
 import hashlib
 import tarfile
 import unittest
-from gettext import gettext as _
 
 import mock
 


### PR DESCRIPTION
I am not sure why this started failing, but this commit fixes the import order
so flake8-import-order does not complain.