### PR TITLE
repo.working_dir can be None

### DIFF
--- a/plugins/pulp_python/plugins/distributors/web.py
+++ b/plugins/pulp_python/plugins/distributors/web.py
@@ -126,7 +126,10 @@ class PythonDistributor(Distributor):
                     configuration.get_web_publish_dir(repo, config)]
 
         for repo_dir in dir_list:
-            shutil.rmtree(repo_dir, ignore_errors=True)
+            # in case repo_dir is None
+            # ignore_errors set to True does not cover this.
+            if repo_dir:
+                shutil.rmtree(repo_dir, ignore_errors=True)
 
     def validate_config(self, repo, config, config_conduit):
         """

--- a/plugins/test/unit/plugins/distributors/test_web.py
+++ b/plugins/test/unit/plugins/distributors/test_web.py
@@ -56,6 +56,21 @@ class TestBasics(unittest.TestCase):
 
         self.assertEquals(0, len(os.listdir(self.working_dir)))
 
+    @patch('pulp_python.plugins.distributors.web.configuration.get_master_publish_dir')
+    @patch('pulp_python.plugins.distributors.web.configuration.get_web_publish_dir')
+    def test_distributor_removed_dir_is_none(self, mock_web, mock_master):
+
+        mock_web.return_value = os.path.join(self.working_dir, 'web')
+        mock_master.return_value = os.path.join(self.working_dir, 'master')
+        repo_working_dir = None
+        os.makedirs(mock_web.return_value)
+        os.makedirs(mock_master.return_value)
+        repo = Mock(id='bar', working_dir=repo_working_dir)
+        config = {}
+        self.distributor.distributor_removed(repo, config)
+
+        self.assertEquals(0, len(os.listdir(self.working_dir)))
+
     @patch('pulp_python.plugins.distributors.web.PythonPublisher')
     def test_publish_repo(self, mock_publisher):
         repo = Repository('test')


### PR DESCRIPTION
I encountered an error where if you delete a repository after adding something to it but before publishing it, repo.working_dir is None, which causes an error in the distributor_removed routine.

Traceback:
https://paste.fedoraproject.org/279066/82722614/
Reproduced:
http://fpaste.org/279071/27799144/
https://pulp.plan.io/issues/1349

This was fixed in pulp_ostree in an identical method:
https://pulp.plan.io/issues/1096
https://github.com/pulp/pulp_ostree/commit/49274ee493dff222ffcc82985238abfa6e25d220