### PR TITLE
Ignore D104 in our pep257 checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "pypy"
 before_install:
   - "pushd .."
   - "git clone https://github.com/pulp/pulp.git --branch 2.7-dev"

--- a/run-tests.py
+++ b/run-tests.py
@@ -24,7 +24,7 @@ if exit_code != 0:
 
 # Check the code for PEP-257 compliance
 # We should remove some of these over time
-pep257_fail_ignore_codes = 'D100,D103,D200,D202,D203,D205,D400,D401,D402'
+pep257_fail_ignore_codes = 'D100,D103,D104,D200,D202,D203,D205,D400,D401,D402'
 
 print "checking pep257 for failures, ignoring %s" % pep257_fail_ignore_codes
 exit_code = subprocess.call(['pep257', '--ignore=' + pep257_fail_ignore_codes])

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,7 @@ coverage
 coveralls
 flake8
 flake8-import-order
-mock
+mock<1.1
 nose
 nosexcover
 pep257


### PR DESCRIPTION
D104 gets upset about our empty __init__.py files. This commit configures the pep257 checker to ignore that error.