### PR TITLE
Ensure file objects are cleaned up on error

### DIFF
--- a/plugins/pulp_python/plugins/importers/importer.py
+++ b/plugins/pulp_python/plugins/importers/importer.py
@@ -183,8 +183,7 @@ class PythonImporter(Importer):
         :rtype:           dict
         """
         package = models.Package.from_archive(file_path)
-        package.save()
-        package.import_content(file_path)
+        package.save_and_import_content(file_path)
         repo_controller.associate_single_unit(repo.repo_obj, package)
 
         return {'success_flag': True, 'summary': {}, 'details': {}}

--- a/plugins/pulp_python/plugins/importers/sync.py
+++ b/plugins/pulp_python/plugins/importers/sync.py
@@ -145,8 +145,7 @@ class DownloadPackagesStep(publish_step.DownloadStep):
 
         package = models.Package.from_archive(report.destination)
         try:
-            package.save()
-            package.import_content(report.destination)
+            package.save_and_import_content(report.destination)
         except mongoengine.NotUniqueError:
             package = models.Package.objects.get(name=package.name, version=package.version)
 

--- a/plugins/test/unit/plugins/importers/test_importer.py
+++ b/plugins/test/unit/plugins/importers/test_importer.py
@@ -165,8 +165,7 @@ class TestPythonImporter(unittest.TestCase):
 
         self.assertEqual(report, {'success_flag': True, 'summary': {}, 'details': {}})
         from_archive.assert_called_once_with(file_path)
-        package.save.assert_called_once_with()
-        package.import_content.assert_called_once_with(file_path)
+        package.save_and_import_content.assert_called_once_with(file_path)
         mock_associate.assert_called_once_with(repo.repo_obj, package)
 
     def test_validate_config(self):

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -595,8 +595,8 @@ class TestDownloadPackagesStep(unittest.TestCase):
         checksum.assert_called_once_with(report.destination, 'md5')
         # The from_archive method should have been given the destination
         from_archive.assert_called_once_with(report.destination)
-        from_archive.return_value.save.assert_called_once_with()
-        from_archive.return_value.import_content.assert_called_once_with(report.destination)
+        from_archive.return_value.save_and_import_content\
+            .assert_called_once_with(report.destination)
         mock_associate.assert_called_once_with(step.parent.get_repo.return_value.repo_obj,
                                                from_archive.return_value)
 
@@ -619,11 +619,11 @@ class TestDownloadPackagesStep(unittest.TestCase):
         package = from_archive.return_value
         package.name = 'foo'
         package.version = '1.0.0'
-        package.save.side_effect = mongoengine.NotUniqueError
+        package.save_and_import_content.side_effect = mongoengine.NotUniqueError
 
         step.download_succeeded(report)
 
-        package.save.assert_called_once_with()
+        package.save_and_import_content.assert_called()
         self.assertEqual(package.import_content.call_count, 0)
         mock_associate.assert_called_once_with(step.parent.get_repo.return_value.repo_obj,
                                                mock_objects.get.return_value)


### PR DESCRIPTION
Call save_and_import_content().

Utilize cleanup pattern instead where usage doesn't
fit.

re #[1457](https://pulp.plan.io/issues/1457)
https://pulp.plan.io/issues/1457