### PR TITLE
Enable proxy support in pulp_python by default

### DIFF
--- a/extensions_admin/pulp_python/extensions/admin/cudl.py
+++ b/extensions_admin/pulp_python/extensions/admin/cudl.py
@@ -26,7 +26,7 @@ IMPORTER_CONFIGURATION_FLAGS = dict(
     include_ssl=False,
     include_sync=True,
     include_unit_policy=False,
-    include_proxy=False,
+    include_proxy=True,
     include_throttling=False
 )
 


### PR DESCRIPTION
We would like to see proxy support be enabled by default for the `pulp_python` plugin.