### PR TITLE
Fix broken http config

### DIFF
--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -26,7 +26,6 @@ ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 
 LINKS = (
     ('plugins/etc/httpd/conf.d/pulp_python.conf', '/etc/httpd/conf.d/pulp_python.conf'),
-    ('plugins/etc/pulp/vhosts80/pulp_python.conf', '/etc/pulp/vhosts80/pulp_python.conf'),
     ('plugins/etc/pulp/server/plugins.conf.d/python_distributor.json',
      '/etc/pulp/server/plugins.conf.d/python_distributor.json'),
 )


### PR DESCRIPTION
pulp_puppet.conf was removed, but dev script was still creating
a link to it.  Removing the link.

closes #[1611](https://pulp.plan.io/issues/1611)
https://pulp.plan.io/issues/1611