### PR TITLE
Configure Travis to only flake8 and pep257 the code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
-before_install:
-  - "pushd .."
-  - "git clone https://github.com/pulp/pulp.git --branch 2.7-dev"
-  - "git clone https://github.com/pulp/nectar.git"
-  - "pushd nectar"
-  - "git checkout python-nectar-1.1.6-1"
-  - "popd"
-  - "popd"
 install:
-  # This is needed to build M2Crypto
-  - "sudo apt-get install swig"
   - "pip install -r test_requirements.txt"
-  - "pushd .."
-  - "python nectar/setup.py develop"
-  - "pulp/manage_setup_pys.sh develop"
-  - "popd"
-  - "./manage_setup_pys.sh develop"
-  - "sudo mkdir -p /etc/pulp"
-  - "sudo touch /etc/pulp/server.conf"
 script:
-  - "./run-tests.py --enable-coverage --cover-min-percentage 100"
-after_success: coveralls
+  - "flake8 --import-order-style google --application-import-names pulp_python.common --config flake8.cfg ."
+  - "pep257 --ignore=D100,D103,D104,D200,D202,D203,D205,D400,D401,D402"


### PR DESCRIPTION
We have spent too much time maintaining our travis file. It
regularly breaks and is often difficult to debug. Since we
primarily use Jenkins, we don't really need Travis though it does
provide some additional value. The current problems are taking too
long to sort out to justify the time, so this commit adjusts it to
only run flake8 and pep257 on the code. We can re-enable it later
if we have the time and desire to do so.