### PR TITLE
Create new model for python packages

### DIFF
--- a/plugins/pulp_python/plugins/migrations/0002_smaller_model_for_json.py
+++ b/plugins/pulp_python/plugins/migrations/0002_smaller_model_for_json.py
@@ -1,0 +1,22 @@
+"""
+This migration removes `home_page`, `platform`, 'author_email`, `description` and `license` from
+the units_python_package collection. Additionally, it renames `_filename` to `filename`.
+"""
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+    """
+    db = connection.get_database()
+    collection = db['units_python_package']
+
+    collection.update({}, {"$unset": {"home_page": True}}, multi=True)
+    collection.update({}, {"$unset": {"platform": True}}, multi=True)
+    collection.update({}, {"$unset": {"license": True}}, multi=True)
+    collection.update({}, {"$unset": {"_metadata_file": True}}, multi=True)
+    collection.update({}, {"$unset": {"description": True}}, multi=True)
+    collection.update({}, {"$unset": {"author_email": True}}, multi=True)
+
+    collection.update({}, {"$rename": {"_filename": "filename"}}, multi=True)

--- a/plugins/pulp_python/plugins/models.py
+++ b/plugins/pulp_python/plugins/models.py
@@ -1,120 +1,124 @@
-from gettext import gettext as _
 import hashlib
-import re
-import tarfile
 
 from mongoengine import StringField
 from pulp.server.db.model import FileContentUnit
+import twine  # noqa
 
 from pulp_python.common import constants
 
 
 DEFAULT_CHECKSUM_TYPE = 'sha512'
-
-
-# These are required to be in the PKG-INFO file.
-REQUIRED_ATTRS = ('name', 'version', 'summary', 'home_page', 'author', 'author_email', 'license',
-                  'description', 'platform')
+REQUIRED_ATTRS = ('name', 'version', 'author', 'summary')
 
 
 class Package(FileContentUnit):
     """
     This class represents a Python package.
+
+    Packages stored on PyPI have significantly more metadata associated with them, but we have
+    chosen to keep this model minimal. Below is an explanation for why this was done.
+
+    There are some overloaded terms that should be briefly discussed. We will be using the
+    semantics of PEP 426. https://www.python.org/dev/peps/pep-0426/#id14
+
+    Package - An individual, installable python package. A package is defined by the project,
+              target architecture, and Python version. Note that there may not be a target
+              architecture in the case of architecture agnostic packages. A Python version is also
+              optional if there are no requirements for a specific runtime version. There are 3
+              packaging formats: sdist, whl, and zip.
+    Release - A snapshot of the project. A particular release of the project will all share the
+              same version number, but there may be multiple packages for a given release for
+              different architectures, python versions, and package types.
+    Project - The entire group of packages of all releases.
+
+    The way that PyPI stores the metadata on their end leaves this model open to potential
+    inaccuracies. Many packages of the same project share a significant amount of metadata,
+    including mutable fields. In the situation where a mutable field changes between releases, only
+    the latest version is present in the metadata accessible over the API. This is could be
+    particularly problematic for a field like "license". For this reason, most of these fields have
+    been left out of this model. The only fields that are included here are necessary for sync
+    (name, version, filename) or are useful for disambiguation between similarly named projects
+    (author, summary). By keeping the scope of the metadata as small as is reasonable, we have less
+    complexity and reduced risk of innacuracy.
+
+    :ivar name: name of the project, ex. scipy
+    :type name: basestring
+    :ivar version: Contains the distribution's version number. This field must be in the format
+                   specified in PEP 386.
+    :type version: basestring
+    :ivar filename: name of the file containing the package and metadata
+    :type filename: basestring
+    :ivar author: primary author of the package
+    :type author: basesetring
+    :ivar summary: one line summary of what the package does
+    :type summary: basestring
     """
 
-    # unit key
     name = StringField(required=True)
     version = StringField(required=True)
-
+    filename = StringField(required=True)
     author = StringField()
-    author_email = StringField()
-    description = StringField()
-    home_page = StringField()
-    license = StringField()
-    platform = StringField()
     summary = StringField()
 
     _checksum = StringField()
     _checksum_type = StringField(default=DEFAULT_CHECKSUM_TYPE)
-    _filename = StringField()
-    _metadata_file = StringField()
 
     # For backward compatibility
     _ns = StringField(default='units_python_package')
     _content_type_id = StringField(required=True, default=constants.PACKAGE_TYPE_ID)
 
-    unit_key_fields = ('name', 'version')
+    unit_key_fields = ('filename',)
 
     meta = {
         'allow_inheritance': False,
         'collection': 'units_python_package',
-        'indexes': [],
+        'indexes': [{'fields': ['-filename'], 'unique': True}],
     }
 
     @classmethod
-    def from_archive(cls, archive_path):
+    def from_json(cls, package_data, release, project_data):
         """
-        Instantiate a Package using the metadata found inside the Python package found at
-        archive_path. This tarball should be the build result of running setup.py sdist on the
-        package, and should contain a PKG-INFO file. This method will read the PKG-INFO to determine
-        the package's metadata and unit key.
+        Create and return (but do not save) an instance of a single python package object from the
+        metadata available from PyPI JSON.
 
-        :param archive_path: A filesystem path to the Python source distribution that this Package
-                             will represent.
-        :type  archive_path: basestring
-        :return:             An instance of Package that represents the package found at
-                             archive_path.
-        :rtype:              pulp_python.plugins.models.Package
-        :raises:             ValueError if archive_path does not point to a valid Python tarball
-                             created with setup.py sdist.
-        :raises:             IOError if the archive_path does not exist.
+        :param package_data: metadata specific to a file
+        :type  package_data: dict
+        :param release: version number
+        :type  release: basestring
+        :param project_data: metadata that applies to all versions
+        :type  project_data: dict
+        :return: instance of a package
+        :rtype:  pulp_python.plugins.models.Package
         """
-        try:
-            compression_type = cls._compression_type(archive_path)
-            checksum = cls.checksum(archive_path)
-            package_archive = tarfile.open(archive_path)
-            metadata_file = None
-            for member in package_archive.getmembers():
-                if re.match('.*/PKG-INFO$|^PKG-INFO$', member.name):
-                    # find the metadata file with the shortest path
-                    if metadata_file:
-                        if len(member.name) < len(metadata_file.name):
-                            metadata_file = member
-                    else:
-                        metadata_file = member
-            if not metadata_file:
-                msg = _('The archive at %(path)s does not contain a PKG-INFO file.')
-                msg = msg % {'path': archive_path}
-                raise ValueError(msg)
+        package_attrs = {}
+        package_attrs['filename'] = package_data['filename']
+        package_attrs['name'] = project_data['name']
+        package_attrs['version'] = release
+        package_attrs['author'] = project_data['author']
+        package_attrs['summary'] = project_data['summary']
+        return cls(**package_attrs)
 
-            metadata_file_name = metadata_file.name
-            metadata_file = package_archive.extractfile(metadata_file)
-            metadata = metadata_file.read()
+    @classmethod
+    def from_file(cls, path):
+        """
+        Create and return (but do not save) an instance of a python package object from the package
+        itself.
 
-            # Build a list of tuples of all the attributes found in the metadata. Ignore attributes
-            # with a leading underscore, as they are not part of the metadata.
-            attrs = dict()
-            try:
-                for attr in REQUIRED_ATTRS:
-                    attrs[attr] = re.search('^%s: (?P<field>.*?)\s*$' % cls._metadata_label(attr),
-                                            metadata, flags=re.MULTILINE).group('field')
-            except AttributeError:
-                msg = _('The PKG-INFO file is missing required attributes. Please ensure that the '
-                        'following attributes are all present: %(attrs)s')
-                msg = msg % {
-                    'attrs': ', '.join([cls._metadata_label(attr) for attr in REQUIRED_ATTRS])}
-                raise ValueError(msg)
+        Twine is smart enough to crack open a tarball, zip, or wheel and parse the metadata that is
+        contained in the package.
 
-            # Add the filename, checksum, and checksum_type to the attrs
-            attrs['_filename'] = '%s-%s.tar%s' % (attrs['name'], attrs['version'], compression_type)
-            attrs['_checksum'] = checksum
-            attrs['_checksum_type'] = DEFAULT_CHECKSUM_TYPE
-            attrs['_metadata_file'] = metadata_file_name
-            package = cls(**attrs)
-            return package
-        finally:
-            if 'package_archive' in locals():
-                package_archive.close()
+        :param path: path to the package
+        :type  path: basestring
+        :return: instance of a package
+        :rtype:  pulp_python.plugins.models.Package
+        """
+
+        meta_dict = twine.package.PackageFile.from_filename(path, comment='').metadata_dictionary()
+        filtered_dict = {}
+        for key, value in meta_dict.iteritems():
+            if key in REQUIRED_ATTRS:
+                filtered_dict[key] = value
+        return cls(**filtered_dict)
 
     @staticmethod
     def checksum(path, algorithm=DEFAULT_CHECKSUM_TYPE):
@@ -136,44 +140,6 @@ class Package(FileContentUnit):
                 hasher.update(bits)
                 bits = file_handle.read(chunk_size)
         return hasher.hexdigest()
-
-    @staticmethod
-    def _compression_type(path):
-        """
-        Return the type of compression used in the file at path. Can be '', '.bz2', '.gz', or
-        '.zip'. '' is returned if the file at path matches none of the magic signatures. This
-        algorithm is based on http://stackoverflow.com/a/13044946.
-
-        :param path: The path to the file you wish to test for compression type.
-        :type  path: basestring
-        :return:     File extension used to represent the compression type found at path.
-        :rtype:      basestring
-        """
-        magic_dict = {
-            "\x1f\x8b\x08": ".gz",
-            "\x42\x5a\x68": ".bz2",
-            "\x50\x4b\x03\x04": ".zip"
-        }
-        # We need to read the first four bytes of the file to compare
-        with open(path) as the_file:
-            header = the_file.read(4)
-        for magic, filetype in magic_dict.items():
-            if header.startswith(magic):
-                return filetype
-        return ''
-
-    @staticmethod
-    def _metadata_label(attribute):
-        """
-        Return the label in the PKG-INFO file that corresponds to the given attribute.
-
-        :param attribute: The attribute on a Package for which you wish to know the PKG-INFO label
-        :type  attribute: basestring
-        :return:          The label in the PKG-INFO file that can be used to get the field
-        :rtype:           basestring
-        """
-        label = attribute[0].upper() + attribute[1:]
-        return label.replace('_', '-')
 
     def __repr__(self):
         """

--- a/plugins/test/unit/plugins/migrations/test_0002_smaller_model_for_json.py
+++ b/plugins/test/unit/plugins/migrations/test_0002_smaller_model_for_json.py
@@ -1,0 +1,32 @@
+"""
+This module contains tests for pulp.server.db.migrations.0002_smaller_model_for_json.py
+"""
+import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+PATH_TO_MODULE = 'pulp_python.plugins.migrations.0002_smaller_model_for_json'
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test the migrate() function.
+    """
+
+    @mock.patch.object(migration.connection, 'get_database')
+    def test_repos_collection_id_renamed(self, mock_get_database):
+        mock_get_database.return_value.collection_names.return_value = []
+        collection = mock_get_database.return_value['archived_calls']
+        migration.migrate()
+        collection.update.assert_has_calls([
+            mock.call({}, {"$unset": {"home_page": True}}, multi=True),
+            mock.call({}, {"$unset": {"platform": True}}, multi=True),
+            mock.call({}, {"$unset": {"license": True}}, multi=True),
+            mock.call({}, {"$unset": {"_metadata_file": True}}, multi=True),
+            mock.call({}, {"$unset": {"description": True}}, multi=True),
+            mock.call({}, {"$unset": {"author_email": True}}, multi=True),
+            mock.call({}, {"$rename": {"_filename": "filename"}}, multi=True)
+        ])

--- a/plugins/test/unit/plugins/test_models.py
+++ b/plugins/test/unit/plugins/test_models.py
@@ -1,10 +1,7 @@
 """
 This modules contains tests for pulp_python.plugins.models.
 """
-from gettext import gettext as _
 import hashlib
-import re
-import tarfile
 import unittest
 
 import mock
@@ -12,58 +9,15 @@ import mock
 from pulp_python.plugins import models
 
 
-# The BAD_MANIFEST is missing the Version field.
-BAD_MANIFEST = """Metadata-Version: 1.1
-Name: nectar
-Summary: Performance tuned network download client library
-Home-page: https://github.com/pulp/nectar
-Author: Pulp Team
-Author-email: pulp-list@redhat.com
-License: GPLv2
-Description: UNKNOWN
-Platform: UNKNOWN
-Classifier: Intended Audience :: Developers
-Classifier: Intended Audience :: Information Technology
-Classifier: License :: OSI Approved :: GNU General Public License v2 (GPLv2)
-Classifier: Operating System :: POSIX
-Classifier: Programming Language :: Python :: 2.6
-Classifier: Programming Language :: Python :: 2.7
-Classifier: Topic :: Software Development :: Libraries :: Python Modules"""
-
-GOOD_MANIFEST = """Metadata-Version: 1.1
-Name: nectar
-Version: 1.3.1
-Summary: Performance tuned network download client library
-Home-page: https://github.com/pulp/nectar
-Author: Pulp Team
-Author-email: pulp-list@redhat.com
-License: GPLv2
-Description: UNKNOWN
-Platform: UNKNOWN
-Classifier: Intended Audience :: Developers
-Classifier: Intended Audience :: Information Technology
-Classifier: License :: OSI Approved :: GNU General Public License v2 (GPLv2)
-Classifier: Operating System :: POSIX
-Classifier: Programming Language :: Python :: 2.6
-Classifier: Programming Language :: Python :: 2.7
-Classifier: Topic :: Software Development :: Libraries :: Python Modules"""
-
-
 def make_package():
     return models.Package(
         name='foo',
         version='1.0.0',
         author='Mr Foo',
-        author_email='mrfoo@foo.pulpproject.org',
-        description='Foo for you.',
-        home_page='http://foo.pulpproject.org',
-        license='GPL2',
-        platform='all',
+        filename='foo-1.0.0.tar.gz',
         summary='Foo!',
         _checksum='abc123',
         _checksum_type='md5',
-        _filename='foo-1.0.0.tar.gz',
-        _metadata_file='somefile',
     )
 
 
@@ -71,384 +25,6 @@ class TestPackage(unittest.TestCase):
     """
     This class contains tests for the Package class.
     """
-
-    @mock.patch('pulp_python.plugins.models.Package.checksum', return_value='sum')
-    @mock.patch('pulp_python.plugins.models.Package._compression_type', return_value='.gz')
-    @mock.patch('pulp_python.plugins.models.tarfile.open')
-    def test_from_archive_closely_named_metadata(self, tarfile_open, _compression_type, checksum):
-        """
-        Test from_archive() with files named very similarly to PKG-INFO to test the regex. This also
-        coincidentally tests behavior when the archive is missing metadata.
-        """
-        tarfile_open.return_value = mock.MagicMock(spec=tarfile.TarFile)
-
-        class TarInfo(object):
-            """
-            This class fakes being a TarInfo. It just needs a name.
-            """
-            def __init__(self, name):
-                self.name = name
-
-        members = [TarInfo(name) for name in ['aPKG-INFO', 'PKG-INFO.txt', '/path/to/PKG-INFO.txt'
-                                              '/path/to/aPKG-INFO']]
-        tarfile_open.return_value.getmembers.return_value = members
-        path = '/some/path.tar.gz'
-
-        try:
-            models.Package.from_archive(path)
-            self.fail('The above call should have raised a ValueError!')
-        except ValueError as e:
-            self.assertTrue(
-                _('The archive at %s does not contain a PKG-INFO file.') % path in str(e))
-
-        tarfile_open.assert_called_once_with(path)
-        _compression_type.assert_called_once_with(path)
-        tarfile_open.return_value.close.assert_called_once_with()
-
-    @mock.patch('pulp_python.plugins.models.Package.checksum', return_value='sum')
-    @mock.patch('pulp_python.plugins.models.Package._compression_type', return_value='.gz')
-    @mock.patch('pulp_python.plugins.models.tarfile.open')
-    def test_from_archive_multiple_metadatas(self, tarfile_open, _compression_type, checksum):
-        """
-        Test from_archive() with multiple PKG-INFO files.
-        """
-        tarfile_open.return_value = mock.MagicMock(spec=tarfile.TarFile)
-
-        class TarInfo(object):
-            """
-            This class fakes being a TarInfo. It just needs a name.
-            """
-            def __init__(self, name):
-                self.name = name
-
-        members = [TarInfo(name) for name in ['package-1.2.3/some/stuff/PKG-INFO',
-                                              'package-1.2.3',
-                                              'package-1.2.3/PKG-INFO',
-                                              'package-1.2.3/other/stuff/PKG-INFO']]
-        mock_manifest_file = mock.MagicMock(spec=file)
-        mock_manifest_file.read.return_value = GOOD_MANIFEST
-        tarfile_open.return_value.extractfile.return_value = mock_manifest_file
-        tarfile_open.return_value.getmembers.return_value = members
-        path = '/some/path.tar.gz'
-
-        package = models.Package.from_archive(path)
-
-        self.assertEqual(package._metadata_file, 'package-1.2.3/PKG-INFO')
-
-        tarfile_open.assert_called_once_with(path)
-        _compression_type.assert_called_once_with(path)
-        tarfile_open.return_value.close.assert_called_once_with()
-
-    @mock.patch('pulp_python.plugins.models.Package.checksum', return_value='sum')
-    @mock.patch('pulp_python.plugins.models.Package._compression_type', return_value='.gz')
-    @mock.patch('pulp_python.plugins.models.tarfile.open')
-    def test_from_archive_empty_metadata(self, tarfile_open, _compression_type, checksum):
-        """
-        Test from_archive() when the PKG-INFO file is empty.
-        """
-        tarfile_open.return_value = mock.MagicMock(spec=tarfile.TarFile)
-
-        class TarInfo(object):
-            """
-            This class fakes being a TarInfo. It just needs a name.
-            """
-            def __init__(self, name):
-                self.name = name
-
-        members = [TarInfo(name) for name in ['package-1.2.3', 'package-1.2.3/PKG-INFO']]
-        tarfile_open.return_value.getmembers.return_value = members
-        mock_manifest_file = mock.MagicMock(spec=file)
-        mock_manifest_file.read.return_value = ''
-        tarfile_open.return_value.extractfile.return_value = mock_manifest_file
-        path = '/some/path.tar.gz'
-
-        try:
-            models.Package.from_archive(path)
-            self.fail('The above call should have raised a ValueError!')
-        except ValueError as e:
-            self.assertTrue('The PKG-INFO file is missing required attributes.' in str(e))
-
-        tarfile_open.assert_called_once_with(path)
-        _compression_type.assert_called_once_with(path)
-        tarfile_open.return_value.extractfile.assert_called_once_with(members[-1])
-        tarfile_open.return_value.close.assert_called_once_with()
-
-    def test_from_archive_file_not_found(self):
-        """
-        Test from_archive() when the given path does not exist.
-        """
-        dne = '/some/path/that/doesnt/exist'
-
-        self.assertRaises(IOError, models.Package.from_archive, dne)
-
-    @mock.patch('pulp_python.plugins.models.Package.checksum', return_value='sum')
-    @mock.patch('pulp_python.plugins.models.Package._compression_type', return_value='.gz')
-    @mock.patch('pulp_python.plugins.models.tarfile.open')
-    def test_from_archive_good_metadata(self, tarfile_open, _compression_type, checksum):
-        """
-        Test from_archive() with good metadata, with PKG-INFO at the typical location as would be
-        done by setup.py sdist.
-        """
-        tarfile_open.return_value = mock.MagicMock(spec=tarfile.TarFile)
-
-        class TarInfo(object):
-            """
-            This class fakes being a TarInfo. It just needs a name.
-            """
-            def __init__(self, name):
-                self.name = name
-
-        members = [
-            TarInfo(name) for name in ['nectar-1.3.1', 'nectar-1.3.1/nectar',
-                                       'nectar-1.3.1/nectar/config.py',
-                                       'nectar-1.3.1/nectar/downloaders',
-                                       'nectar-1.3.1/nectar/downloaders/threaded.py',
-                                       'nectar-1.3.1/nectar/downloaders/base.py',
-                                       'nectar-1.3.1/nectar/downloaders/__init__.py',
-                                       'nectar-1.3.1/nectar/downloaders/local.py',
-                                       'nectar-1.3.1/nectar/__init__.py',
-                                       'nectar-1.3.1/nectar/exceptions.py',
-                                       'nectar-1.3.1/nectar/listener.py',
-                                       'nectar-1.3.1/nectar/report.py',
-                                       'nectar-1.3.1/nectar/request.py', 'nectar-1.3.1/PKG-INFO']]
-        tarfile_open.return_value.getmembers.return_value = members
-        mock_manifest_file = mock.MagicMock(spec=file)
-        mock_manifest_file.read.return_value = GOOD_MANIFEST
-        tarfile_open.return_value.extractfile.return_value = mock_manifest_file
-        path = '/some/path.tar.gz'
-
-        package = models.Package.from_archive(path)
-
-        self.assertEqual(package.name, 'nectar')
-        self.assertEqual(package.version, '1.3.1')
-        self.assertEqual(package.summary, 'Performance tuned network download client library')
-        self.assertEqual(package.home_page, 'https://github.com/pulp/nectar')
-        self.assertEqual(package.author, 'Pulp Team')
-        self.assertEqual(package.author_email, 'pulp-list@redhat.com')
-        self.assertEqual(package.license, 'GPLv2')
-        self.assertEqual(package.description, 'UNKNOWN')
-        self.assertEqual(package.platform, 'UNKNOWN')
-        self.assertEqual(package._filename, 'nectar-1.3.1.tar.gz')
-        self.assertEqual(package._checksum, 'sum')
-        self.assertEqual(package._checksum_type, 'sha512')
-        checksum.assert_called_once_with(path)
-        tarfile_open.assert_called_once_with(path)
-        _compression_type.assert_called_once_with(path)
-        tarfile_open.return_value.extractfile.assert_called_once_with(members[-1])
-        tarfile_open.return_value.close.assert_called_once_with()
-
-    @mock.patch('pulp_python.plugins.models.Package.checksum', return_value='sum')
-    @mock.patch('pulp_python.plugins.models.Package._compression_type', return_value='.gz')
-    @mock.patch('pulp_python.plugins.models.tarfile.open')
-    def test_from_archive_dos_metadata(self, tarfile_open, _compression_type, checksum):
-        """
-        Test from_archive() with good metadata that has DOS line endings, with
-        PKG-INFO at the typical location as would be done by setup.py sdist.
-        """
-        tarfile_open.return_value = mock.MagicMock(spec=tarfile.TarFile)
-
-        class TarInfo(object):
-            """
-            This class fakes being a TarInfo. It just needs a name.
-            """
-            def __init__(self, name):
-                self.name = name
-
-        members = [
-            TarInfo(name) for name in ['nectar-1.3.1', 'nectar-1.3.1/nectar',
-                                       'nectar-1.3.1/nectar/config.py',
-                                       'nectar-1.3.1/nectar/downloaders',
-                                       'nectar-1.3.1/nectar/downloaders/threaded.py',
-                                       'nectar-1.3.1/nectar/downloaders/base.py',
-                                       'nectar-1.3.1/nectar/downloaders/__init__.py',
-                                       'nectar-1.3.1/nectar/downloaders/local.py',
-                                       'nectar-1.3.1/nectar/__init__.py',
-                                       'nectar-1.3.1/nectar/exceptions.py',
-                                       'nectar-1.3.1/nectar/listener.py',
-                                       'nectar-1.3.1/nectar/report.py',
-                                       'nectar-1.3.1/nectar/request.py', 'nectar-1.3.1/PKG-INFO']]
-        tarfile_open.return_value.getmembers.return_value = members
-        mock_manifest_file = mock.MagicMock(spec=file)
-        mock_manifest_file.read.return_value = re.sub(r'\n', '\r\n', GOOD_MANIFEST)
-        tarfile_open.return_value.extractfile.return_value = mock_manifest_file
-        path = '/some/path.tar.gz'
-
-        package = models.Package.from_archive(path)
-
-        self.assertEqual(package.name, 'nectar')
-        self.assertEqual(package.version, '1.3.1')
-        self.assertEqual(package.summary, 'Performance tuned network download client library')
-        self.assertEqual(package.home_page, 'https://github.com/pulp/nectar')
-        self.assertEqual(package.author, 'Pulp Team')
-        self.assertEqual(package.author_email, 'pulp-list@redhat.com')
-        self.assertEqual(package.license, 'GPLv2')
-        self.assertEqual(package.description, 'UNKNOWN')
-        self.assertEqual(package.platform, 'UNKNOWN')
-        self.assertEqual(package._filename, 'nectar-1.3.1.tar.gz')
-        self.assertEqual(package._checksum, 'sum')
-        self.assertEqual(package._checksum_type, 'sha512')
-        checksum.assert_called_once_with(path)
-        tarfile_open.assert_called_once_with(path)
-        _compression_type.assert_called_once_with(path)
-        tarfile_open.return_value.extractfile.assert_called_once_with(members[-1])
-        tarfile_open.return_value.close.assert_called_once_with()
-
-    @mock.patch('pulp_python.plugins.models.Package.checksum', return_value='sum')
-    @mock.patch('pulp_python.plugins.models.Package._compression_type', return_value='.gz')
-    @mock.patch('pulp_python.plugins.models.tarfile.open')
-    def test_from_archive_metadata_at_absolute_root(self, tarfile_open, _compression_type,
-                                                    checksum):
-        """
-        Test from_archive() with good metadata when the PKG-INFO file is at /.
-        """
-        tarfile_open.return_value = mock.MagicMock(spec=tarfile.TarFile)
-
-        class TarInfo(object):
-            """
-            This class fakes being a TarInfo. It just needs a name.
-            """
-            def __init__(self, name):
-                self.name = name
-
-        members = [
-            TarInfo(name) for name in ['/PKG-INFO', 'nectar-1.3.1', 'nectar-1.3.1/nectar',
-                                       'nectar-1.3.1/nectar/config.py',
-                                       'nectar-1.3.1/nectar/downloaders',
-                                       'nectar-1.3.1/nectar/downloaders/threaded.py',
-                                       'nectar-1.3.1/nectar/downloaders/base.py',
-                                       'nectar-1.3.1/nectar/downloaders/__init__.py',
-                                       'nectar-1.3.1/nectar/downloaders/local.py',
-                                       'nectar-1.3.1/nectar/__init__.py',
-                                       'nectar-1.3.1/nectar/exceptions.py',
-                                       'nectar-1.3.1/nectar/listener.py',
-                                       'nectar-1.3.1/nectar/report.py',
-                                       'nectar-1.3.1/nectar/request.py']]
-        tarfile_open.return_value.getmembers.return_value = members
-        mock_manifest_file = mock.MagicMock(spec=file)
-        mock_manifest_file.read.return_value = GOOD_MANIFEST
-        tarfile_open.return_value.extractfile.return_value = mock_manifest_file
-        path = '/some/path.tar.gz'
-
-        package = models.Package.from_archive(path)
-
-        self.assertEqual(package.name, 'nectar')
-        self.assertEqual(package.version, '1.3.1')
-        self.assertEqual(package.summary, 'Performance tuned network download client library')
-        self.assertEqual(package.home_page, 'https://github.com/pulp/nectar')
-        self.assertEqual(package.author, 'Pulp Team')
-        self.assertEqual(package.author_email, 'pulp-list@redhat.com')
-        self.assertEqual(package.license, 'GPLv2')
-        self.assertEqual(package.description, 'UNKNOWN')
-        self.assertEqual(package.platform, 'UNKNOWN')
-        self.assertEqual(package._filename, 'nectar-1.3.1.tar.gz')
-        self.assertEqual(package._checksum, 'sum')
-        self.assertEqual(package._checksum_type, 'sha512')
-        checksum.assert_called_once_with(path)
-        tarfile_open.assert_called_once_with(path)
-        _compression_type.assert_called_once_with(path)
-        tarfile_open.return_value.extractfile.assert_called_once_with(members[0])
-        tarfile_open.return_value.close.assert_called_once_with()
-
-    @mock.patch('pulp_python.plugins.models.Package.checksum', return_value='sum')
-    @mock.patch('pulp_python.plugins.models.Package._compression_type', return_value='.gz')
-    @mock.patch('pulp_python.plugins.models.tarfile.open')
-    def test_from_archive_metadata_at_root(self, tarfile_open, _compression_type, checksum):
-        """
-        Test from_archive() when the PKG-INFO file is at the root of the archive.
-        """
-        tarfile_open.return_value = mock.MagicMock(spec=tarfile.TarFile)
-
-        class TarInfo(object):
-            """
-            This class fakes being a TarInfo. It just needs a name.
-            """
-            def __init__(self, name):
-                self.name = name
-
-        members = [
-            TarInfo(name) for name in ['nectar-1.3.1', 'nectar-1.3.1/nectar',
-                                       'nectar-1.3.1/nectar/config.py',
-                                       'nectar-1.3.1/nectar/downloaders',
-                                       'nectar-1.3.1/nectar/downloaders/threaded.py',
-                                       'nectar-1.3.1/nectar/downloaders/base.py',
-                                       'nectar-1.3.1/nectar/downloaders/__init__.py',
-                                       'nectar-1.3.1/nectar/downloaders/local.py',
-                                       'nectar-1.3.1/nectar/__init__.py',
-                                       'nectar-1.3.1/nectar/exceptions.py',
-                                       'nectar-1.3.1/nectar/listener.py',
-                                       'nectar-1.3.1/nectar/report.py',
-                                       'nectar-1.3.1/nectar/request.py', 'PKG-INFO']]
-        tarfile_open.return_value.getmembers.return_value = members
-        mock_manifest_file = mock.MagicMock(spec=file)
-        mock_manifest_file.read.return_value = GOOD_MANIFEST
-        tarfile_open.return_value.extractfile.return_value = mock_manifest_file
-        path = '/some/path.tar.gz'
-
-        package = models.Package.from_archive(path)
-
-        self.assertEqual(package.name, 'nectar')
-        self.assertEqual(package.version, '1.3.1')
-        self.assertEqual(package.summary, 'Performance tuned network download client library')
-        self.assertEqual(package.home_page, 'https://github.com/pulp/nectar')
-        self.assertEqual(package.author, 'Pulp Team')
-        self.assertEqual(package.author_email, 'pulp-list@redhat.com')
-        self.assertEqual(package.license, 'GPLv2')
-        self.assertEqual(package.description, 'UNKNOWN')
-        self.assertEqual(package.platform, 'UNKNOWN')
-        self.assertEqual(package._filename, 'nectar-1.3.1.tar.gz')
-        self.assertEqual(package._checksum, 'sum')
-        self.assertEqual(package._checksum_type, 'sha512')
-        checksum.assert_called_once_with(path)
-        tarfile_open.assert_called_once_with(path)
-        _compression_type.assert_called_once_with(path)
-        tarfile_open.return_value.extractfile.assert_called_once_with(members[-1])
-        tarfile_open.return_value.close.assert_called_once_with()
-
-    @mock.patch('pulp_python.plugins.models.Package.checksum', return_value='sum')
-    @mock.patch('pulp_python.plugins.models.Package._compression_type', return_value='.gz')
-    @mock.patch('pulp_python.plugins.models.tarfile.open')
-    def test_from_archive_missing_required_metadata(self, tarfile_open, _compression_type,
-                                                    checksum):
-        """
-        Test from_archive() when the PKG-INFO file is missing required fields.
-        """
-        tarfile_open.return_value = mock.MagicMock(spec=tarfile.TarFile)
-
-        class TarInfo(object):
-            """
-            This class fakes being a TarInfo. It just needs a name.
-            """
-            def __init__(self, name):
-                self.name = name
-
-        members = [
-            TarInfo(name) for name in ['nectar-1.3.1', 'nectar-1.3.1/nectar',
-                                       'nectar-1.3.1/nectar/config.py',
-                                       'nectar-1.3.1/nectar/downloaders',
-                                       'nectar-1.3.1/nectar/downloaders/threaded.py',
-                                       'nectar-1.3.1/nectar/downloaders/base.py',
-                                       'nectar-1.3.1/nectar/downloaders/__init__.py',
-                                       'nectar-1.3.1/nectar/downloaders/local.py',
-                                       'nectar-1.3.1/nectar/__init__.py',
-                                       'nectar-1.3.1/nectar/exceptions.py',
-                                       'nectar-1.3.1/nectar/listener.py',
-                                       'nectar-1.3.1/nectar/report.py',
-                                       'nectar-1.3.1/nectar/request.py', 'nectar-1.3.1/PKG-INFO']]
-        tarfile_open.return_value.getmembers.return_value = members
-        mock_manifest_file = mock.MagicMock(spec=file)
-        mock_manifest_file.read.return_value = BAD_MANIFEST
-        tarfile_open.return_value.extractfile.return_value = mock_manifest_file
-        path = '/some/path.tar.gz'
-        try:
-            models.Package.from_archive(path)
-            self.fail('The above call should have raised a ValueError!')
-        except ValueError as e:
-            self.assertTrue(_('The PKG-INFO file is missing required attributes.') in str(e))
-
-        tarfile_open.assert_called_once_with(path)
-        _compression_type.assert_called_once_with(path)
-        tarfile_open.return_value.extractfile.assert_called_once_with(members[-1])
-        tarfile_open.return_value.close.assert_called_once_with()
 
     @mock.patch('__builtin__.open')
     def test_checksum_default_sum(self, mock_open):
@@ -498,92 +74,29 @@ class TestPackage(unittest.TestCase):
         hasher.update('Hello World!')
         self.assertEqual(checksum, hasher.hexdigest())
 
-    @mock.patch('pulp_python.plugins.models.open', create=True)
-    def test__compression_type_empty_file(self, mock_open):
+    def test_from_json(self):
         """
-        Test that _compression_type() correctly handles empty files.
+        Test that the data needed to instantiate a package comes from the right part of the JSON.
         """
-        mock_file = mock.MagicMock(spec=file)
-        mock_file.__enter__.return_value.read.return_value = ''
-        mock_open.return_value = mock_file
-        path = '/some/path/to/hello_world'
+        mock_pkg_attrs = {'filename': "m_file"}
+        mock_release = "1.0.2"
+        mock_dist_data = {"author": "me", "name": "test", "summary": "does stuff"}
+        package = models.Package.from_json(mock_pkg_attrs, mock_release, mock_dist_data)
+        self.assertEqual(package.filename, 'm_file')
+        self.assertEqual(package.version, '1.0.2')
+        self.assertEqual(package.author, 'me')
+        self.assertEqual(package.summary, 'does stuff')
 
-        compression_type = models.Package._compression_type(path)
-
-        # Since "" isn't a magic string, the empty string should have been returned.
-        self.assertEqual(compression_type, '')
-        mock_open.assert_called_once_with(path)
-
-    @mock.patch('pulp_python.plugins.models.open', create=True)
-    def test__compression_type_handle_other(self, mock_open):
+    @mock.patch('pulp_python.plugins.models.twine')
+    def test_from_file(self, m_twine):
         """
-        Test that _compression_type() correctly handles other files.
+        Ensure that before init, metadata from twine is filtered leaving only required fields.
         """
-        mock_file = mock.MagicMock(spec=file)
-        mock_file.__enter__.return_value.read.return_value = 'Hello World!'
-        mock_open.return_value = mock_file
-        path = '/some/path/to/hello_world'
-
-        compression_type = models.Package._compression_type(path)
-
-        # Since "Hello World!" isn't a magic string, the empty string should have been returned.
-        self.assertEqual(compression_type, '')
-        mock_open.assert_called_once_with(path)
-
-    @mock.patch('pulp_python.plugins.models.open', create=True)
-    def test__compression_type_match_bz2(self, mock_open):
-        """
-        Test that _compression_type() correctly matches bz2 files.
-        """
-        mock_file = mock.MagicMock(spec=file)
-        mock_file.__enter__.return_value.read.return_value = '\x42\x5a\x68Hello World!'
-        mock_open.return_value = mock_file
-        path = '/some/path/to/hello_world.bz2'
-
-        compression_type = models.Package._compression_type(path)
-
-        self.assertEqual(compression_type, '.bz2')
-        mock_open.assert_called_once_with(path)
-
-    @mock.patch('pulp_python.plugins.models.open', create=True)
-    def test__compression_type_match_gz(self, mock_open):
-        """
-        Test that _compression_type() correctly matches gz files.
-        """
-        mock_file = mock.MagicMock(spec=file)
-        mock_file.__enter__.return_value.read.return_value = '\x1f\x8b\x08Hello World!'
-        mock_open.return_value = mock_file
-        path = '/some/path/to/hello_world.gz'
-
-        compression_type = models.Package._compression_type(path)
-
-        self.assertEqual(compression_type, '.gz')
-        mock_open.assert_called_once_with(path)
-
-    @mock.patch('pulp_python.plugins.models.open', create=True)
-    def test__compression_type_match_zip(self, mock_open):
-        """
-        Test that _compression_type() correctly matches zip files.
-        """
-        mock_file = mock.MagicMock(spec=file)
-        mock_file.__enter__.return_value.read.return_value = '\x50\x4b\x03\x04Hello World!'
-        mock_open.return_value = mock_file
-        path = '/some/path/to/hello_world.zip'
-
-        compression_type = models.Package._compression_type(path)
-
-        self.assertEqual(compression_type, '.zip')
-        mock_open.assert_called_once_with(path)
-
-    def test__metadata_label(self):
-        """
-        Test various manipulations of possible metadata attributes with the _metadata_label()
-        method.
-        """
-        expected_value_map = {'name': 'Name', 'author_email': 'Author-email', 'a': 'A'}
-
-        for key, value in expected_value_map.items():
-            self.assertEqual(models.Package._metadata_label(key), value)
+        twine_to_dict = m_twine.package.PackageFile.from_filename.return_value.metadata_dictionary
+        twine_to_dict.return_value = {'name': 'necessary', 'extra_field': 'do not include'}
+        package = models.Package.from_file('mock_path')
+        self.assertEqual(package.name, 'necessary')
+        self.assertFalse(hasattr(package, 'extra_field'))
 
     def test___repr__(self):
         """


### PR DESCRIPTION
Please note, this is being merged to a feature branch which will contain this commit and others to get sync and publish working. Because this is only changing the model, it is expected that any tests outside of `plugins/test/unit/plugins/test_models.py` may fail.

The filename contains the name, version, platform, and python versions.
This means that filename is guaranteed to be unique on PyPI.
Additionally, this commit removes some unecessary field names to prevent
them from being wrongly populated with data from a later release, which
will occur if the packages are built from the JSON metadata from PyPI.

closes #1882