### PR TITLE
Reverting strict mode so that Koji can build RPMs again

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W -n
+SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
Koji does not allow for the loading of intersphinx inv files
due to Mock's restriction of internet access during build time.

This will get reintroduced later after we have a better plan
for how to handle intersphinx in our Koji environment.

re #950
https://pulp.plan.io/issues/950