### PR TITLE
Refactor to process uploaded files with twine

### DIFF
--- a/extensions_admin/pulp_python/extensions/admin/upload.py
+++ b/extensions_admin/pulp_python/extensions/admin/upload.py
@@ -21,16 +21,21 @@ class UploadPackageCommand(upload.UploadCommand):
         """
         return constants.PACKAGE_TYPE_ID
 
-    def generate_unit_key(self, *args, **kwargs):
+    def generate_unit_key(self, filename, *args, **kwargs):
         """
-        We don't need to generate the unit key client-side, but the superclass requires us to define
-        this method. It returns the empty dictionary.
+        Generates the unit key for a Python unit, which is the filename.
 
-        :param args:   Unused
-        :type  args:   list
-        :param kwargs: Unused
-        :type  kwargs: dict
-        :return:       An empty dictionary
-        :rtype:        dict
+        Unfortunately, what is passed in as "filename" here is actually a relative path to the
+        file, not just the filename. I have chosen to leave the argument named as it is because
+        this function is implementing behavior defined in core, and the variable name is set there.
+
+        :param filename: path to the file which is being uploaded
+        :type  filename: basestring
+        :param args:     Unused
+        :type  args:     list
+        :param kwargs:   Unused
+        :type  kwargs:   dict
+        :return:         An empty dictionary
+        :rtype:          dict
         """
-        return {}
+        return {"filename": filename.split('/')[-1]}

--- a/extensions_admin/test/unit/admin/test_upload.py
+++ b/extensions_admin/test/unit/admin/test_upload.py
@@ -26,10 +26,20 @@ class TestUploadPackageCommand(unittest.TestCase):
 
     def test_generate_unit_key(self):
         """
-        Assert that generate_unit_key() returns the empty dictionary.
+        Assert that generate_unit_key() returns the filename.
         """
         command = upload.UploadPackageCommand(mock.MagicMock())
 
         key = command.generate_unit_key('some', 'args', and_some='kwargs')
 
-        self.assertEqual(key, {})
+        self.assertEqual(key, {'filename': 'some'})
+
+    def test_generate_unit_key_with_path(self):
+        """
+        Assert that generate_unit_key() returns the filename, even when it is passed a path.
+        """
+        command = upload.UploadPackageCommand(mock.MagicMock())
+
+        key = command.generate_unit_key('path/mock_file', 'args', and_some='kwargs')
+
+        self.assertEqual(key, {'filename': 'mock_file'})

--- a/plugins/pulp_python/plugins/models.py
+++ b/plugins/pulp_python/plugins/models.py
@@ -2,13 +2,13 @@ import hashlib
 
 from mongoengine import StringField
 from pulp.server.db.model import FileContentUnit
-import twine  # noqa
+from twine.package import PackageFile  # noqa
 
 from pulp_python.common import constants
 
 
 DEFAULT_CHECKSUM_TYPE = 'sha512'
-REQUIRED_ATTRS = ('name', 'version', 'author', 'summary')
+PACKAGE_ATTRS = ('author', 'name', 'packagetype', 'summary', 'url', 'version')
 
 
 class Package(FileContentUnit):
@@ -112,7 +112,7 @@ class Package(FileContentUnit):
         return cls(**package_attrs)
 
     @classmethod
-    def from_file(cls, path):
+    def from_archive(cls, path):
         """
         Create and return (but do not save) an instance of a python package object from the package
         itself.
@@ -125,12 +125,13 @@ class Package(FileContentUnit):
         :return: instance of a package
         :rtype:  pulp_python.plugins.models.Package
         """
-
-        meta_dict = twine.package.PackageFile.from_filename(path, comment='').metadata_dictionary()
+        meta_dict = PackageFile.from_filename(path, comment='').metadata_dictionary()
         filtered_dict = {}
+        # Use only a subset of the attributes in the metadata to keep package minimal.
         for key, value in meta_dict.iteritems():
-            if key in REQUIRED_ATTRS:
+            if key in PACKAGE_ATTRS:
                 filtered_dict[key] = value
+        filtered_dict['filename'] = path.split('/')[-1]
         return cls(**filtered_dict)
 
     @staticmethod

--- a/plugins/test/unit/plugins/importers/test_importer.py
+++ b/plugins/test/unit/plugins/importers/test_importer.py
@@ -162,32 +162,34 @@ class TestUploadUnit(unittest.TestCase):
         super(TestUploadUnit, self).setUp()
         self.repo = mock.MagicMock()
         self.type_id = constants.PACKAGE_TYPE_ID
-        self.unit_key = {}
+        self.unit_key = {'filename': '1234'}
         self.metadata = {}
         self.file_path = '/some/path/1234'
         self.conduit = mock.MagicMock()
         self.config = {}
 
-'''
-TODO (asmacdo) upload units!
+    @mock.patch('pulp_python.plugins.importers.importer.os')
     @mock.patch('pulp.server.controllers.repository.rebuild_content_unit_counts', spec_set=True)
     @mock.patch('pulp.server.controllers.repository.associate_single_unit', spec_set=True)
     @mock.patch('pulp_python.plugins.models.Package.from_archive')
-    def test_upload_unit(self, from_archive, mock_associate, mock_rebuild):
+    def test_upload_unit(self, from_archive, mock_associate, mock_rebuild, mock_os):
         """
         Assert upload_unit() works correctly and reports a success.
         """
+        working_dir = mock_os.path.dirname.return_value
         package = from_archive.return_value
         python_importer = importer.PythonImporter()
         report = python_importer.upload_unit(self.repo, self.type_id, self.unit_key, self.metadata,
                                              self.file_path, self.conduit, self.config)
-        from_archive.assert_called_once_with(self.file_path)
-        package.save_and_import_content.assert_called_once_with(self.file_path)
+        mock_os.path.join.assert_called_once_with(working_dir, self.unit_key['filename'])
+        from_archive.assert_called_once_with(mock_os.path.join.return_value)
+        package.save_and_import_content.assert_called_once_with(mock_os.path.join.return_value)
         mock_associate.assert_called_once_with(self.repo.repo_obj, package)
         self.assertTrue(report['success_flag'])
 
+    @mock.patch('pulp_python.plugins.importers.importer.os')
     @mock.patch('pulp_python.plugins.models.Package.from_archive')
-    def test_upload_unit_failure(self, from_archive):
+    def test_upload_unit_failure(self, from_archive, mock_os):
         """
         Assert that upload_unit() reports failure.
         """
@@ -198,4 +200,3 @@ TODO (asmacdo) upload units!
                                              self.file_path, self.conduit, self.config)
         self.assertFalse(report['success_flag'])
         self.assertEqual(report['summary'], expected_msg)
-'''

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -514,16 +514,13 @@ class TestDownloadMetadataStep(unittest.TestCase):
         super_download_succeeded.assert_called_once_with(report)
         _process_metadata.assert_called_once_with(NUMPY_MANIFEST)
 
-    ''' TODO (asmacdo) uncomment after upload
     @mock.patch('pulp_python.plugins.importers.sync.models.Package.from_json')
     def test__process_metadata(self, mock_from_json):
         step = sync.DownloadMetadataStep('sync_step_download_metadata', conduit=mock.MagicMock())
         step.parent = mock.MagicMock()
         step._process_metadata(NUMPY_MANIFEST)
-        import ipdb
-        ipdb.set_trace()
-        self.assertEqual(mock_from_json.call_count, 27)
-    '''
+        # 1.9.1 has 5 units, 1.9.0 has 5, 1.8.0 has 2, 1.8.1 has 5, 1.8.2 has 5. Total should be 22.
+        self.assertEqual(mock_from_json.call_count, 22)
 
 
 class TestDownloadPackagesStep(unittest.TestCase):

--- a/plugins/test/unit/plugins/test_models.py
+++ b/plugins/test/unit/plugins/test_models.py
@@ -88,14 +88,14 @@ class TestPackage(unittest.TestCase):
         self.assertEqual(package.author, 'me')
         self.assertEqual(package.summary, 'does stuff')
 
-    @mock.patch('pulp_python.plugins.models.twine')
+    @mock.patch('pulp_python.plugins.models.PackageFile')
     def test_from_file(self, m_twine):
         """
         Ensure that before init, metadata from twine is filtered leaving only required fields.
         """
-        twine_to_dict = m_twine.package.PackageFile.from_filename.return_value.metadata_dictionary
+        twine_to_dict = m_twine.from_filename.return_value.metadata_dictionary
         twine_to_dict.return_value = {'name': 'necessary', 'extra_field': 'do not include'}
-        package = models.Package.from_file('mock_path')
+        package = models.Package.from_archive('mock_path')
         self.assertEqual(package.name, 'necessary')
         self.assertFalse(hasattr(package, 'extra_field'))
 


### PR DESCRIPTION
By generating the unit key (which for Python is the filename), we are
able to rename the tempororary file (the filename is a random uuid)
to the actual filename. This allows twine to determine the file type
so it can be processed accordingly.

closes #136