### PR TITLE
Publish metadata to allow pulp to pulp sync

### DIFF
--- a/plugins/etc/httpd/conf.d/pulp_python.conf
+++ b/plugins/etc/httpd/conf.d/pulp_python.conf
@@ -8,4 +8,6 @@ Alias /pulp/python /var/www/pub/python/
 
 <Directory /var/www/pub/python>
     Options FollowSymLinks Indexes
+    DirectoryIndex index.html index.json
 </Directory>
+

--- a/plugins/pulp_python/plugins/distributors/steps.py
+++ b/plugins/pulp_python/plugins/distributors/steps.py
@@ -91,7 +91,7 @@ class PublishMetadataStep(PluginStep):
         for name, packages in projects.items():
             project_metadata_path = os.path.join(api_path, name, 'json')
             os.makedirs(project_metadata_path)
-            project_index_metadata_path = os.path.join(project_metadata_path, 'index.html')
+            project_index_metadata_path = os.path.join(project_metadata_path, 'index.json')
             with open(project_index_metadata_path, 'w') as meta_json:
                 data = PublishMetadataStep._create_metadata(name, packages)
                 meta_json.write(json.dumps(data))

--- a/plugins/pulp_python/plugins/models.py
+++ b/plugins/pulp_python/plugins/models.py
@@ -51,7 +51,7 @@ class Package(FileContentUnit):
     :type name: basestring
     :ivar packagetype: format of python package, ex bdist_wheel, sdist
     :type packagetype: basestring
-    :ivar url: url that the package can be downloaded from
+    :ivar url: url that is the source of bits for this package
     :type url: basestring
     :ivar version: Contains the distribution's version number. This field must be in the format
                    specified in PEP 386.


### PR DESCRIPTION
Publishes a json metadata file for each python project that contains
metadata for each python package that belongs to it. This is a subset of
the api that PyPI implements, and allows a Pulp to sync from another
Pulp in exactly the same way that it would sync from PyPI itself.

closes #140