### PR TITLE
Remove intersphinx and enable Strict mode

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/admin-docs/configuration.rst
+++ b/docs/admin-docs/configuration.rst
@@ -9,5 +9,4 @@ The Python importer is configured by editing
 
 .. _JSON: http://json.org/
 
-The importer supports the settings documented in Pulp's
-:ref:`importer config docs <platform:importer_settings>`.
+The importer supports the settings documented in Pulp's importer config docs.

--- a/docs/admin-docs/installation.rst
+++ b/docs/admin-docs/installation.rst
@@ -5,8 +5,7 @@ Prerequisites
 -------------
 
 These instructions assume that you have a working Pulp installation first. If you have not yet
-installed Pulp, please follow the Pulp :ref:`installation <platform:server_installation>`
-instructions, and then return to this document.
+installed Pulp, please follow the Pulp installation instructions, and then return to this document.
 
 The command line examples included here are written for systems that use yum as their package
 manager, and systemd as their init system. Please season to taste if your system is different.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ except ImportError:
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.extlinks', 'sphinx.ext.intersphinx']
+extensions = ['sphinx.ext.extlinks']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -243,13 +243,6 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
-
-
-# the "platform" URL needs to point to the correct version of platform docs for
-# this branch of the plugin. It is currently set to "latest" but may change as
-# code is branched and new RTD builders are created for platform.
-intersphinx_mapping = {'pylang': ('http://docs.python.org/2.7/', None),
-                       'platform': ("http://pulp.readthedocs.org/en/latest/", None)}
 
 extlinks = {'redmine': ('https://pulp.plan.io/issues/%s', '#'),
             'fixedbugs': ('https://pulp.plan.io/projects/pulp_python/issues?c%%5B%%5D=tracker&'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
 Pulp Python Support
 ===================
 
-Welcome to the Pulp Python Plugin documentation. These plugins extend the
-:ref:`Pulp Project <platform:pulp_documentation>` so that it is capable of handling Python packages.
-With these plugins, you can create Python repositories in Pulp, upload Python packages to those
-repositories, and use pip to install packages from client machines.
+Welcome to the Pulp Python Plugin documentation. These plugins extend the Pulp Project so that
+it is capable of handling Python packages. With these plugins, you can create Python
+repositories in Pulp, upload Python packages to those repositories, and use pip to install
+packages from client machines.
 
 We plan to add support for more features in the future, and community contributions are welcome.
 Send us pull requests on `our GitHub repository <https://github.com/pulp/pulp_python>`_. See existing


### PR DESCRIPTION
Intersphinx was preventing the strict mode from being enabled
due to docs being built in a network isolated mock environment.

Intersphinx was also going to break because it is tied
to URLs from ReadTheDocs. Now intersphinx is removed, and
usage of it was dropped from the content. Strict Sphinx
mode is now enabled.

https://pulp.plan.io/issues/2034
re #2034