### PR TITLE
Adds banner warning about migration runtime

### DIFF
--- a/plugins/pulp_python/plugins/migrations/0001_standard_storage_path.py
+++ b/plugins/pulp_python/plugins/migrations/0001_standard_storage_path.py
@@ -1,11 +1,23 @@
+import logging
+
 from pulp.plugins.migration.standard_storage_path import Migration, Plan
 from pulp.server.db import connection
+
+
+_logger = logging.getLogger(__name__)
 
 
 def migrate(*args, **kwargs):
     """
     Migrate content units to use the standard storage path introduced in pulp 2.8.
     """
+    msg = '* NOTE: This migration may take a long time depending on the size of your Pulp content *'
+    stars = '*' * len(msg)
+
+    _logger.info(stars)
+    _logger.info(msg)
+    _logger.info(stars)
+
     migration = Migration()
     migration.add(Package())
     migration()


### PR DESCRIPTION
Migration 1 can take a long time. This outputs a banner to
the logs and the foreground of pulp-manage-db warning the user
that it could take a long time.

https://pulp.plan.io/issues/2060
re #2060