### PR TITLE
Remove flake8-import-order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
 install:
   - "pip install -r test_requirements.txt"
 script:
-  - "flake8 --import-order-style google --application-import-names pulp_python.common --config flake8.cfg ."
+  - "flake8 --config flake8.cfg ."
   - "pep257 --ignore=D100,D103,D104,D200,D202,D203,D205,D400,D401,D402"

--- a/run-tests.py
+++ b/run-tests.py
@@ -15,9 +15,7 @@ subprocess.call(['find', PROJECT_DIR, '-name', '*.pyc', '-delete'])
 
 # Check the code for PEP-8 compliance
 config_file = os.path.join(PROJECT_DIR, 'flake8.cfg')
-exit_code = subprocess.call(['flake8', '--import-order-style', 'google',
-                             '--application-import-names', 'pulp_python.common',
-                             '--config', config_file, PROJECT_DIR])
+exit_code = subprocess.call(['flake8', '--config', config_file, PROJECT_DIR])
 
 if exit_code != 0:
     sys.exit(exit_code)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,6 @@
 coverage
 coveralls
 flake8
-flake8-import-order
 mock<1.1
 nose
 nosexcover


### PR DESCRIPTION
Fixes broken test runner for systems that install flake8 3.0 (including fedora 24 vagrant dev environment).

flake8 3.0 introduced a backwards incompatible change in the config that
breaks some flake8 plugins including flake8-import-order. Since this
plugin has also had some occasional unexpected behavior, we should just
remove it for now.