### PR TITLE
Problem: release notes for 2.0.0 are nonexistent

### DIFF
--- a/docs/release-notes/2.0.rst
+++ b/docs/release-notes/2.0.rst
@@ -1,0 +1,27 @@
+2.0 Release Notes
+=================
+
+2.0.0
+-----
+
+This release adds ability to manage Python wheel packages. Wheel is currently considered the
+standard for built and binary packaging for Python. More information about the differences between
+sdist and wheel formats can be found in the `Python Packaging User Guide
+<https://packaging.python.org/wheel_egg/>`_. Wheel packages can now be both uploaded and synced
+from PyPi. When syncing from PyPi both sdist and wheel packages are synced. This results in many
+packages existing in both formats in the Pulp Python repositories. This behavior maintains support
+for older pip clients that are not aware of the wheel format.
+
+Requirements
+^^^^^^^^^^^^
+The 2.0.x releases of the Python plugins depend on the Pulp 2.12.x or greater.
+
+Bugfixes
+^^^^^^^^
+
+This release also contains some minor bugfixes. See the :fixedbugs:`2.0.0`.
+
+Known Issues
+^^^^^^^^^^^^
+
+:redmine:`2554`

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -6,3 +6,4 @@ Release Notes
 
    1.0
    1.1
+   2.0


### PR DESCRIPTION
Solution: Add release notes for 2.0.0

closes #2537
https://pulp.plan.io/issues/2537