### PR TITLE
Add provides for python2-* packages

### DIFF
--- a/pulp-python.spec
+++ b/pulp-python.spec
@@ -69,6 +69,7 @@ rm -rf %{buildroot}
 %package -n python-pulp-python-common
 Summary: Pulp Python support common library
 Group: Development/Languages
+Provides: python2-pulp-python-common
 Requires: python-pulp-common >= %{pulp_version}
 Requires: python-setuptools
 


### PR DESCRIPTION
Add provides for python2-* packages.  Fedora downstream packages are
named python2-* and provide python-*.  Upstream needs to mirror this for
dependency resolution to work properly

re #2687