### PR TITLE
Sync succeeds even when feed or package-names is not specified

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Mike Adams <mike.adams@unix-security.net>
+Muhammad Ammar Ansari <mansari@redhat.com>
 Randy Barlow <rbarlow@redhat.com>
 Graham Forest <graham@urbanairship.com>
 Sayli Karmarkar <skarmark@redhat.com>

--- a/docs/reference/importer.rst
+++ b/docs/reference/importer.rst
@@ -4,4 +4,5 @@ Importer Reference
 The Python importer supports the standard Pulp importer keys, as well as one custom config key:
 
 package_names: This key is a comma separated list of the names of the packages that should be
-                synchronized from the feed URL.
+                synchronized from the feed URL. Sync will fail if either package_names or feed
+                URL is missing.


### PR DESCRIPTION
An appropriate error message will now be displayed
when a user tries to sync a python repo that is
missing feed or package-names

closes #2964