### PR TITLE
Add sync to pulp_python

### DIFF
--- a/pulp_python/app/models.py
+++ b/pulp_python/app/models.py
@@ -1,11 +1,25 @@
-from logging import getLogger
+import json
+import os
 
+from collections import namedtuple
+from logging import getLogger
+from urllib.parse import urljoin, urlparse
+
+from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
-from pulpcore.plugin.models import Content, Importer, Publisher
-from django.contrib.postgres.fields import ArrayField
+from pulpcore.plugin.models import (Artifact, Content, Importer, Publisher)
+
+from pulpcore.plugin.changeset import (
+    ChangeSet,
+    PendingArtifact,
+    PendingContent,
+    SizedIterable
+)
 
 log = getLogger(__name__)
+
+Delta = namedtuple('Delta', ('additions', 'removals'))
 
 
 class Classifier(models.Model):
@@ -41,25 +55,25 @@ class PythonPackageContent(Content):
     packagetype = models.TextField(blank=False)
     name = models.TextField(blank=False)
     version = models.TextField(blank=False)
-    metadata_version = models.TextField(blank=False)
-    summary = models.TextField()
-    description = models.TextField()
-    keywords = ArrayField(models.TextField())
-    home_page = models.TextField()
-    download_url = models.TextField()
-    author = models.TextField()
-    author_email = models.TextField()
-    maintainer = models.TextField()
-    maintainer_email = models.TextField()
-    license = models.TextField()
-    requires_python = models.TextField()
-    project_url = models.TextField()
-    platform = models.TextField()
-    supported_platform = models.TextField()
-    requires_dist = ArrayField(models.TextField())
-    provides_dist = ArrayField(models.TextField())
-    obsoletes_dist = ArrayField(models.TextField())
-    requires_external = ArrayField(models.TextField())
+    metadata_version = models.TextField(null=True)
+    summary = models.TextField(null=True)
+    description = models.TextField(null=True)
+    keywords = models.TextField(null=True)
+    home_page = models.TextField(null=True)
+    download_url = models.TextField(null=True)
+    author = models.TextField(null=True)
+    author_email = models.TextField(null=True)
+    maintainer = models.TextField(null=True)
+    maintainer_email = models.TextField(null=True)
+    license = models.TextField(null=True)
+    requires_python = models.TextField(null=True)
+    project_url = models.TextField(null=True)
+    platform = models.TextField(null=True)
+    supported_platform = models.TextField(null=True)
+    requires_dist = ArrayField(models.TextField(), default=[])
+    provides_dist = ArrayField(models.TextField(), default=[])
+    obsoletes_dist = ArrayField(models.TextField(), default=[])
+    requires_external = ArrayField(models.TextField(), default=[])
 
 
 class PythonPublisher(Publisher):
@@ -83,18 +97,173 @@ class PythonPublisher(Publisher):
 
 class PythonImporter(Importer):
     """
-    An Importer for PythonContent.
+    An Importer for Python Content.
 
-    Define any additional fields for your new importer if needed.
-    A ``sync`` method should be defined.
-    It is responsible for parsing metadata of the content,
-    downloading of the content and saving it to Pulp.
+    Attributes:
+        project_names (list): A list of python projects to sync
     """
 
     TYPE = 'python'
+    projects = ArrayField(models.TextField())
+
+    def _fetch_inventory(self):
+        """
+        Fetch existing contentunits in the repository.
+
+        Returns:
+            set: of contentunit filenames.
+        """
+        inventory = set()
+
+        q_set = PythonPackageContent.objects.filter(repositories=self.repository)
+        q_set = q_set.only("filename")
+        for content in (c.cast() for c in q_set):
+            inventory.add(content.filename)
+        return inventory
+
+    def _fetch_remote(self):
+        """
+        Fetch contentunits available  on the remote repository.
+
+        Returns:
+            list: of contentunit metadata.
+        """
+        remote = []
+
+        metadata_urls = [urljoin(self.feed_url, 'pypi/%s/json' % project)
+                         for project in self.project_names]
+
+        for metadata_url in metadata_urls:
+            parsed_url = urlparse(metadata_url)
+
+            download = self.get_futures_downloader(metadata_url, os.path.basename(parsed_url.path))
+            download()
+
+            metadata = json.load(open(download.writer.path))
+            for version, packages in metadata['releases'].items():
+                for package in packages:
+                    remote.append(self._parse_metadata(metadata['info'], version, package))
+
+        return remote
+
+    def _find_delta(self, inventory, remote, mirror=False):
+        """
+        Using the existing and remote set of filenames, determine the set of content to be
+        added and deleted from the repository.
+
+        Parameters:
+            inventory (set): existing natural keys (filename) of content associated
+                with the repository
+            remote (set): metadata keys (filename) of packages on the remote index
+            mirror (bool): When true, any content removed from remote repository is added to
+                the delta.removals. When false, delta.removals is an empty set.
+
+        Returns:
+            Delta (namedtuple): tuple of content to add, and content to remove from the repository
+        """
+
+        additions = remote - inventory
+        removals = inventory - remote if mirror else set()
+
+        return Delta(additions=additions, removals=removals)
+
+    def _parse_metadata(cls, project, version, distribution):
+        """
+        Create a dictionary of metadata needed to create a PythonContentUnit from
+        the project, version, and distribution metadata
+        :param project:
+        :param version:
+        :param distribution:
+        Returns:
+            dictionary: of useful python metadata
+        """
+
+        package = {}
+
+        package['filename'] = distribution['filename']
+        package['packagetype'] = distribution['packagetype']
+        package['name'] = project['name']
+        package['version'] = version
+        package['metadata_version'] = project.get('metadata_version')
+        package['summary'] = project.get('summary')
+        package['description'] = project.get('description')
+        package['keywords'] = project.get('keywords')
+        package['home_page'] = project.get('home_page')
+        package['download_url'] = project.get('download_url')
+        package['author'] = project.get('author')
+        package['author_email'] = project.get('author_email')
+        package['maintainer'] = project.get('maintainer')
+        package['maintainer_email'] = project.get('maintainer_email')
+        package['license'] = project.get('license')
+        package['requires_python'] = project.get('requires_python')
+        package['project_url'] = project.get('project_url')
+        package['platform'] = project.get('platform')
+        package['supported_platform'] = project.get('supported_platform')
+        package['requires_dist'] = project.get('requires_dist', [])
+        package['provides_dist'] = project.get('provides_dist', [])
+        package['obsoletes_dist'] = project.get('obsoletes_dist', [])
+        package['requires_external'] = project.get('requires_external', [])
+        package['url'] = distribution['url']
+        package['md5_digest'] = distribution['md5_digest']
+
+        return package
+
+    def _build_additions(self, additions, remote_metadata):
+        """
+        Generate the content to be added.
+
+        Returns:
+            generator: A generator of content to be added.
+        """
+        for entry in remote_metadata:
+            if(entry['filename'] not in additions):
+                continue
+
+            url = entry.pop('url')
+            artifact = Artifact(md5=entry.pop('md5_digest'))
+
+            package = PythonPackageContent(**entry)
+            content = PendingContent(
+                package,
+                artifacts={
+                    PendingArtifact(model=artifact, url=url, relative_path=entry['filename'])
+                })
+            yield content
+
+    def _build_removals(self, removals):
+        """
+        Generate the content to be removed.
+
+        Returns:
+            generator: A generator of content to be removed.
+        """
+        q = models.Q()
+        for content_key in removals:
+            q |= models.Q(pythonpackagecontent__filename=content_key)
+            q_set = self.repository.content.filter(q)
+            q_set = q_set.only('id')
+            for content in q_set:
+                yield content
 
     def sync(self):
         """
-        Synchronize the repository with the remote repository.
+        Sync the python projects listed on a :class:`pulp_python.app.models.PythonImporter`
+        from a remote repository
         """
-        raise NotImplementedError
+
+        inventory = self._fetch_inventory()
+        remote_metadata = self._fetch_remote()
+        remote_keys = set([content['filename'] for content in remote_metadata])
+
+        mirror = self.sync_mode == 'mirror'
+        delta = self._find_delta(inventory=inventory, remote=remote_keys,
+                                 mirror=mirror)
+
+        additions = SizedIterable(
+            self._build_additions(delta.additions, remote_metadata),
+            len(delta.additions))
+        removals = SizedIterable(
+            self._build_removals(delta.removals),
+            len(delta.removals))
+        changeset = ChangeSet(self, additions=additions, removals=removals)
+        changeset.apply_and_drain()

--- a/pulp_python/app/serializers.py
+++ b/pulp_python/app/serializers.py
@@ -164,19 +164,16 @@ class PythonPackageContentSerializer(platform.ContentSerializer):
 class PythonImporterSerializer(platform.ImporterSerializer):
     """
     A Serializer for PythonImporter.
-
-    Add any new fields if defined on PythonImporter.
-    Similar to the example above, in PythonContentSerializer.
-    Additional validators can be added to the parent validators list
-
-    For example::
-
-    class Meta:
-        validators = platform.ImporterSerializer.Meta.validators + [myValidator1, myValidator2]
     """
 
+    projects = serializers.ListField(
+        child=serializers.CharField(),
+        required=True,
+        help_text=_('A list of project names to sync.')
+    )
+
     class Meta:
-        fields = platform.ImporterSerializer.Meta.fields
+        fields = platform.ImporterSerializer.Meta.fields + ('projects',)
         model = models.PythonImporter
         validators = platform.ImporterSerializer.Meta.validators
 

--- a/pulp_python/tests/test_models.py
+++ b/pulp_python/tests/test_models.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+from pulp_python.app.models import PythonPackageContent, PythonImporter
+from pulpcore.plugin.models import Repository, RepositoryContent
+
+
+class ImportersTestCase(TestCase):
+
+    def setUp(self):
+
+        repo1 = Repository.objects.create(name='repo1')
+        self.importer1 = PythonImporter.objects.create(
+            name='importer1', download_policy='immediate', sync_mode='mirror',
+            repository=repo1, project_names=[])
+        content = PythonPackageContent.objects.create(
+            filename='filename', packagetype='bdist_wheel',
+            name='project', version='0.0.1')
+
+        RepositoryContent.objects.create(repository=repo1, content=content)
+
+    def test_fetch_inventory(self):
+
+        remote = self.importer1._fetch_inventory()
+        self.assertEqual(remote, {'filename'})
+
+    def test_find_delta_mirror_true(self):
+
+        inventory = set(['test1', 'test3'])
+        remote = set(['test1', 'test2'])
+        delta = self.importer1._find_delta(inventory, remote, True)
+
+        self.assertEqual(len(delta.additions), 1)
+        self.assertTrue('test2' in delta.additions)
+
+        self.assertEqual(len(delta.removals), 1)
+        self.assertTrue('test3' in delta.removals)
+
+    def test_find_delta_mirror_false(self):
+
+        inventory = set(['test1', 'test3'])
+        remote = set(['test1', 'test2'])
+        delta = self.importer1._find_delta(inventory, remote, False)
+
+        self.assertEqual(len(delta.additions), 1)
+        self.assertTrue('test2' in delta.additions)
+
+        self.assertEqual(len(delta.removals), 0)


### PR DESCRIPTION
## Testing:

Create Importer:
`http POST http://localhost:8000/api/v3/importers/python/ name='bar' download_policy='immediate' sync_mode='mirror' feed_url='https://test.pypi.org' repository='http://localhost:8000/api/v3/repositories/ed57db7c-16f2-416e-b4df-b12b372fe9a5/' projects:='["pulpcore", "Django"]'`

Sync:
`http POST http://localhost:8000/api/v3/importers/python/{importer-id}/sync/`

## TODO

- [x] unittests
- [x] doc strings
- [x] flake8 failures
- [ ] figure out sane max_length default