### PR TITLE
Remove trailing slash from json api.

### DIFF
--- a/plugins/pulp_python/plugins/importers/sync.py
+++ b/plugins/pulp_python/plugins/importers/sync.py
@@ -75,7 +75,7 @@ class DownloadMetadataStep(publish_step.DownloadStep):
         :return: A generator that yields DownloadRequests for a project's json metadata.
         :rtype:  generator
         """
-        metadata_urls = [urljoin(self.parent._feed_url, 'pypi/%s/json/' % pn)
+        metadata_urls = [urljoin(self.parent._feed_url, 'pypi/%s/json' % pn)
                          for pn in self.parent._project_names]
         for u in metadata_urls:
             if self.canceled:

--- a/plugins/test/unit/plugins/importers/test_sync.py
+++ b/plugins/test/unit/plugins/importers/test_sync.py
@@ -469,7 +469,7 @@ class TestDownloadMetadataStep(unittest.TestCase):
 
         self.assertEqual(len(requests), 1)
         request = requests[0]
-        self.assertEqual(request.url, 'http://pulpproject.org/pypi/foo/json/')
+        self.assertEqual(request.url, 'http://pulpproject.org/pypi/foo/json')
         self.assertEqual(type(request.destination), type(StringIO()))
 
     def test_generate_download_requests_canceled(self):


### PR DESCRIPTION
This is caused by the warehouse migrations- the json api works
differently in warehousem and a trailing slash would cause it
to be redirected to a different location.

fixes #3578
https://pulp.plan.io/issues/3578