### PR TITLE
Keywords string serialized to Char not List

### DIFF
--- a/pulp_python/app/serializers.py
+++ b/pulp_python/app/serializers.py
@@ -53,10 +53,9 @@ class PythonPackageContentSerializer(core_serializers.ContentSerializer):
         required=False, allow_blank=True,
         help_text=_('A longer description of the package that can run to several paragraphs.')
     )
-    keywords = serializers.ListField(
-        child=serializers.CharField(),
-        required=False, default=[],
-        help_text=_('A list of additional keywords to be used to assist searching for the '
+    keywords = serializers.CharField(
+        required=False, allow_blank=True,
+        help_text=_('Additional keywords to be used to assist searching for the '
                     'package in a larger catalog.')
     )
     home_page = serializers.CharField(

--- a/pulp_python/app/utils.py
+++ b/pulp_python/app/utils.py
@@ -17,7 +17,7 @@ def parse_project_metadata(project):
     package['metadata_version'] = project.get('metadata_version') or ""
     package['summary'] = project.get('summary') or ""
     package['description'] = project.get('description') or ""
-    package['keywords'] = project.get('keywords') or []
+    package['keywords'] = project.get('keywords') or ""
     package['home_page'] = project.get('home_page') or ""
     package['download_url'] = project.get('download_url') or ""
     package['author'] = project.get('author') or ""


### PR DESCRIPTION
The keywords serializer was serializing a string to a list.
Now it is serializing to a char instead.

fixes #3628
https://pulp.plan.io/issues/3628