### PR TITLE
Update travis settings to deploy to PyPI on 3.0 tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,19 @@ after_failure:
   - sh -c "cat ~/django_runserver.log"
   - sh -c "cat ~/resource_manager.log"
   - sh -c "cat ~/reserved_workers-1.log"
+stages:
+- name: test
+- name: deploy
+  if: tag =~ ^3.0.0*
+jobs:
+  include:
+  - stage: deploy
+    script: skip
+    deploy:
+      provider: pypi
+      distributions: sdist bdist_wheel
+      user: pulp
+      password:
+        secure: O/1r6kCPWggV5sjmFACgGeml1dgMy8w46ku3atUiXyK5gJIVexbTMIXgLkpfTSu58ODBGoaW+ML6SQmC1K+82Vjq1OMURfrhvzolgSBhREMfM9lNjA52SoKCLzq4ldP31pOy/z3Z9T76vAJOWF7uI80jd2QJ2p+p6h101REl1dk=
+      on:
+        tags: true

--- a/pulp_python/tests/functional/api_v3/test_crd_publications.py
+++ b/pulp_python/tests/functional/api_v3/test_crd_publications.py
@@ -4,7 +4,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH, DISTRIBUTION_PATH, PUBLICATIONS_PATH
-from pulp_smash.tests.pulp3.utils import get_auth, publish_repo, sync_repo
+from pulp_smash.tests.pulp3.utils import get_auth, publish, sync
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 
 from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_PYPI_URL, # noqa
@@ -31,7 +31,7 @@ class PublicationsTestCase(unittest.TestCase, utils.SmokeTest):
             body = gen_remote(PYTHON_PYPI_URL)
             cls.remote.update(cls.client.post(PYTHON_REMOTE_PATH, body))
             cls.publisher.update(cls.client.post(PYTHON_PUBLISHER_PATH, gen_publisher()))
-            sync_repo(cls.cfg, cls.remote, cls.repo)
+            sync(cls.cfg, cls.remote, cls.repo)
         except Exception:
             cls.tearDownClass()
             raise
@@ -46,7 +46,7 @@ class PublicationsTestCase(unittest.TestCase, utils.SmokeTest):
     def test_01_create_publication(self):
         """Create a publication."""
         self.publication.update(
-            publish_repo(self.cfg, self.publisher, self.repo)
+            publish(self.cfg, self.publisher, self.repo)
         )
 
     @selectors.skip_if(bool, 'publication', False)

--- a/pulp_python/tests/functional/api_v3/test_download_content.py
+++ b/pulp_python/tests/functional/api_v3/test_download_content.py
@@ -6,7 +6,7 @@ from unittest import skip
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import DISTRIBUTION_PATH, REPO_PATH
-from pulp_smash.tests.pulp3.utils import get_auth, sync_repo, publish_repo  # get_content,
+from pulp_smash.tests.pulp3.utils import get_auth, sync, publish  # get_content,
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 
 from pulp_python.tests.functional.constants import (PYTHON_PYPI_URL, PYTHON_REMOTE_PATH,
@@ -56,7 +56,7 @@ class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):
         body = gen_remote(PYTHON_PYPI_URL)
         remote = client.post(PYTHON_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote['_href'])
-        sync_repo(cfg, remote, repo)
+        sync(cfg, remote, repo)
         repo = client.get(repo['_href'])
 
         # Create a publisher.
@@ -64,7 +64,7 @@ class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.addCleanup(client.delete, publisher['_href'])
 
         # Create a publication.
-        publication = publish_repo(cfg, publisher, repo)
+        publication = publish(cfg, publisher, repo)
         self.addCleanup(client.delete, publication['_href'])
 
         # Create a distribution.

--- a/pulp_python/tests/functional/api_v3/test_orphans.py
+++ b/pulp_python/tests/functional/api_v3/test_orphans.py
@@ -5,8 +5,8 @@ from random import choice
 from pulp_smash import api, cli, config, utils
 from pulp_smash.exceptions import CalledProcessError
 from pulp_smash.tests.pulp3.constants import ARTIFACTS_PATH, REPO_PATH
-from pulp_smash.tests.pulp3.utils import (get_auth, get_content, get_repo_versions,  # noqa
-                                          delete_orphans, delete_repo_version, sync_repo)
+from pulp_smash.tests.pulp3.utils import (get_auth, get_content, get_version_hrefs,  # noqa
+                                          delete_orphans, delete_version, sync)
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 
 
@@ -59,7 +59,7 @@ class DeleteOrphansTestCase(unittest.TestCase, utils.SmokeTest):
         body = gen_remote(PYTHON_PYPI_URL)
         remote = self.api_client.post(PYTHON_REMOTE_PATH, body)
         self.addCleanup(self.api_client.delete, remote['_href'])
-        sync_repo(self.cfg, remote, repo)
+        sync(self.cfg, remote, repo)
         repo = self.api_client.get(repo['_href'])
         content = choice(get_content(repo)['results'])
 
@@ -76,7 +76,7 @@ class DeleteOrphansTestCase(unittest.TestCase, utils.SmokeTest):
 
         # Delete first repo version. The previous removed content unit will be
         # an orphan.
-        delete_repo_version(repo, get_repo_versions(repo)[0])
+        delete_version(repo, get_version_hrefs(repo)[0])
         content_units = self.api_client.get(PYTHON_CONTENT_PATH)['results']
         self.assertIn(content, content_units)
         delete_orphans()

--- a/pulp_python/tests/functional/api_v3/test_publish.py
+++ b/pulp_python/tests/functional/api_v3/test_publish.py
@@ -6,7 +6,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH
-from pulp_smash.tests.pulp3.utils import get_auth, get_repo_versions, sync_repo, publish_repo
+from pulp_smash.tests.pulp3.utils import get_auth, get_version_hrefs, sync, publish
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 
 from pulp_python.tests.functional.constants import (PYTHON_CONTENT_PATH, PYTHON_PYPI_URL,
@@ -46,7 +46,7 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
         self.addCleanup(client.delete, remote['_href'])
         repo = client.post(REPO_PATH, gen_repo())
         self.addCleanup(client.delete, repo['_href'])
-        sync_repo(cfg, remote, repo)
+        sync(cfg, remote, repo)
         publisher = client.post(PYTHON_PUBLISHER_PATH, gen_publisher())
         self.addCleanup(client.delete, publisher['_href'])
 
@@ -58,17 +58,17 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
                 repo['_versions_href'],
                 {'add_content_units': [file_content['_href']]}
             )
-        versions = get_repo_versions(repo)
+        versions = get_version_hrefs(repo)
         non_latest = choice(versions[:-1])
 
         # Step 2
-        publication = publish_repo(cfg, publisher, repo)
+        publication = publish(cfg, publisher, repo)
 
         # Step 3
         self.assertEqual(publication['repository_version'], versions[-1])
 
         # Step 4
-        publication = publish_repo(cfg, publisher, repo, non_latest)
+        publication = publish(cfg, publisher, repo, non_latest)
 
         # Step 5
         self.assertEqual(publication['repository_version'], non_latest)

--- a/pulp_python/tests/functional/api_v3/test_sync.py
+++ b/pulp_python/tests/functional/api_v3/test_sync.py
@@ -7,7 +7,7 @@ from pulp_smash import api, config, utils
 
 from pulp_smash.tests.pulp3.constants import REPO_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync_repo
+from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync
 
 from pulp_python.tests.functional.constants import (PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH, PYTHON_PACKAGE_COUNT)
@@ -49,13 +49,13 @@ class SyncPythonRepoTestCase(unittest.TestCase, utils.SmokeTest):
 
         # Sync the repository.
         self.assertIsNone(repo['_latest_version_href'])
-        sync_repo(self.cfg, remote, repo)
+        sync(self.cfg, remote, repo)
         repo = client.get(repo['_href'])
         self.assertIsNotNone(repo['_latest_version_href'])
 
         # Sync the repository again.
         latest_version_href = repo['_latest_version_href']
-        sync_repo(self.cfg, remote, repo)
+        sync(self.cfg, remote, repo)
         repo = client.get(repo['_href'])
         self.assertNotEqual(latest_version_href, repo['_latest_version_href'])
 
@@ -91,7 +91,7 @@ class SyncChangeRepoVersionTestCase(unittest.TestCase):
 
         number_of_syncs = randint(1, 10)
         for _ in range(number_of_syncs):
-            sync_repo(cfg, remote, repo)
+            sync(cfg, remote, repo)
 
         repo = client.get(repo['_href'])
         path = urlsplit(repo['_latest_version_href']).path
@@ -131,7 +131,7 @@ class MultiResourceLockingTestCase(unittest.TestCase, utils.SmokeTest):
         self.addCleanup(client.delete, remote['_href'])
         url = {'url': PYTHON_PYPI_URL}
         client.patch(remote['_href'], url)
-        sync_repo(cfg, remote, repo)
+        sync(cfg, remote, repo)
         repo = client.get(repo['_href'])
         remote = client.get(remote['_href'])
         self.assertEqual(remote['url'], url['url'])

--- a/pulp_python/tests/functional/api_v3/test_unlinking_repo.py
+++ b/pulp_python/tests/functional/api_v3/test_unlinking_repo.py
@@ -3,7 +3,7 @@ import unittest
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync_repo, publish_repo
+from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync, publish
 
 from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_PYPI_URL, # noqa
                                                     PYTHON_REMOTE_PATH)
@@ -49,7 +49,7 @@ class RemotesPublishersTestCase(unittest.TestCase, utils.SmokeTest):
         for _ in range(2):
             repo = client.post(REPO_PATH, gen_repo())
             self.addCleanup(client.delete, repo['_href'])
-            sync_repo(cfg, remote, repo)
+            sync(cfg, remote, repo)
             repos.append(client.get(repo['_href']))
 
         # Compare contents of repositories.
@@ -64,7 +64,7 @@ class RemotesPublishersTestCase(unittest.TestCase, utils.SmokeTest):
         # Publish repositories.
         publications = []
         for repo in repos:
-            publications.append(publish_repo(cfg, publisher, repo))
+            publications.append(publish(cfg, publisher, repo))
             if selectors.bug_is_testable(3354, cfg.pulp_version):
                 self.addCleanup(client.delete, publications[-1]['_href'])
         self.assertEqual(


### PR DESCRIPTION
Instruction on using this change to deploy a release is located here: https://pulp.plan.io/projects/pulp/wiki/Pulp3_Release_Guide#Releasing-a-Plugin