### PR TITLE
Only use qualified noqa pragmas, and as needed

### DIFF
--- a/pulp_python/tests/functional/api_v3/test_crd_publications.py
+++ b/pulp_python/tests/functional/api_v3/test_crd_publications.py
@@ -7,10 +7,10 @@ from pulp_smash.tests.pulp3.constants import REPO_PATH, DISTRIBUTION_PATH, PUBLI
 from pulp_smash.tests.pulp3.utils import get_auth, publish, sync
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 
-from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_PYPI_URL, # noqa
+from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH)
-from pulp_python.tests.functional.utils import (gen_remote, gen_publisher,  # noqa
-                                               set_up_module as setUpModule)
+from pulp_python.tests.functional.utils import gen_remote, gen_publisher
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 
 class PublicationsTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_python/tests/functional/api_v3/test_crud_publishers.py
+++ b/pulp_python/tests/functional/api_v3/test_crud_publishers.py
@@ -8,7 +8,8 @@ from pulp_smash.tests.pulp3.utils import get_auth
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 
 from pulp_python.tests.functional.constants import PYTHON_PUBLISHER_PATH
-from pulp_python.tests.functional.utils import gen_publisher, set_up_module as setUpModule  # noqa
+from pulp_python.tests.functional.utils import gen_publisher
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 
 class CRUDPublishersTestCase(unittest.TestCase):

--- a/pulp_python/tests/functional/api_v3/test_crud_remotes.py
+++ b/pulp_python/tests/functional/api_v3/test_crud_remotes.py
@@ -8,7 +8,8 @@ from pulp_smash.tests.pulp3.utils import get_auth
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 
 from pulp_python.tests.functional.constants import PYTHON_PYPI_URL, PYTHON_REMOTE_PATH
-from pulp_python.tests.functional.utils import gen_remote, set_up_module as setUpModule  # noqa
+from pulp_python.tests.functional.utils import gen_remote
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 
 class CRUDRemotesTestCase(unittest.TestCase):

--- a/pulp_python/tests/functional/api_v3/test_download_content.py
+++ b/pulp_python/tests/functional/api_v3/test_download_content.py
@@ -11,8 +11,8 @@ from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 
 from pulp_python.tests.functional.constants import (PYTHON_PYPI_URL, PYTHON_REMOTE_PATH,
                                                     PYTHON_PUBLISHER_PATH)
-from pulp_python.tests.functional.utils import (gen_remote, gen_publisher,   # noqa
-                                                set_up_module as setUpModule)
+from pulp_python.tests.functional.utils import gen_remote, gen_publisher
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 
 @skip("needs better fixtures")

--- a/pulp_python/tests/functional/api_v3/test_orphans.py
+++ b/pulp_python/tests/functional/api_v3/test_orphans.py
@@ -5,15 +5,15 @@ from random import choice
 from pulp_smash import api, cli, config, utils
 from pulp_smash.exceptions import CalledProcessError
 from pulp_smash.tests.pulp3.constants import ARTIFACTS_PATH, REPO_PATH
-from pulp_smash.tests.pulp3.utils import (get_auth, get_content, get_versions,  # noqa
+from pulp_smash.tests.pulp3.utils import (get_auth, get_content, get_versions,
                                           delete_orphans, delete_version, sync)
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 
 
 from pulp_python.tests.functional.constants import (PYTHON_PYPI_URL, PYTHON_REMOTE_PATH,
                                                     PYTHON_CONTENT_PATH)
-from pulp_python.tests.functional.utils import (gen_remote, gen_publisher,   # noqa
-                                                set_up_module as setUpModule)
+from pulp_python.tests.functional.utils import gen_remote
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 from pulp_smash.constants import FILE2_URL
 

--- a/pulp_python/tests/functional/api_v3/test_publish.py
+++ b/pulp_python/tests/functional/api_v3/test_publish.py
@@ -11,8 +11,8 @@ from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 
 from pulp_python.tests.functional.constants import (PYTHON_CONTENT_PATH, PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH, PYTHON_PUBLISHER_PATH)
-from pulp_python.tests.functional.utils import (gen_remote, gen_publisher,  # noqa
-                                                set_up_module as setUpModule)
+from pulp_python.tests.functional.utils import gen_remote, gen_publisher
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 
 class PublishAnyRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_python/tests/functional/api_v3/test_repo_version.py
+++ b/pulp_python/tests/functional/api_v3/test_repo_version.py
@@ -15,8 +15,8 @@ from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_python.tests.functional.constants import (PYTHON_CONTENT_PATH, PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH, PYTHON_PUBLISHER_PATH,
                                                     PYTHON_PACKAGE_COUNT)
-from pulp_python.tests.functional.utils import (gen_remote, gen_publisher,  # noqa
-                                                set_up_module as setUpModule)
+from pulp_python.tests.functional.utils import gen_remote, gen_publisher
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 
 class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_python/tests/functional/api_v3/test_sync.py
+++ b/pulp_python/tests/functional/api_v3/test_sync.py
@@ -11,8 +11,8 @@ from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync
 
 from pulp_python.tests.functional.constants import (PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH, PYTHON_PACKAGE_COUNT)
-from pulp_python.tests.functional.utils import (gen_remote, gen_publisher,  # noqa
-                                                set_up_module as setUpModule)
+from pulp_python.tests.functional.utils import gen_remote
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 
 class SyncPythonRepoTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_python/tests/functional/api_v3/test_unlinking_repo.py
+++ b/pulp_python/tests/functional/api_v3/test_unlinking_repo.py
@@ -5,10 +5,10 @@ from pulp_smash.tests.pulp3.constants import REPO_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync, publish
 
-from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_PYPI_URL, # noqa
+from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH)
-from pulp_python.tests.functional.utils import (gen_remote, gen_publisher,  # noqa
-                                                set_up_module as setUpModule)
+from pulp_python.tests.functional.utils import gen_remote, gen_publisher
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 
 class RemotesPublishersTestCase(unittest.TestCase, utils.SmokeTest):


### PR DESCRIPTION
Don't use the bare `noqa` pragma. Doing so instructs flake8 to ignore
errors other than the one being targeted. In addition, only use the
`noqa` pragma on lines of code that actually trigger a complaint. As a
case in point, consider this code:

    from X import (gen_remote, gen_publisher,   # noqa
                   set_up_module as setUpModule)

This pragma is intended to ignore the fact that `setUpModule` is not
used. However, it ends up ignoring all possible errors triggered by the
two lines of code, including the fact that `gen_publisher` isn't used.
(In some modules.)

This kind of change is especially important given the great number of
changes that Pulp Smash is likely to undergo in the near future.