### PR TITLE
Update imports to account for namespace changes

### DIFF
--- a/pulp_python/tests/functional/api/test_auto_distribution.py
+++ b/pulp_python/tests/functional/api/test_auto_distribution.py
@@ -5,13 +5,13 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, config
 from pulp_smash.tests.pulp3.constants import REPO_PATH, DISTRIBUTION_PATH
-from pulp_smash.tests.pulp3.utils import get_auth, get_added_content, get_versions, publish, sync
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo, gen_distribution
+from pulp_smash.tests.pulp3.utils import (gen_repo, gen_distribution, get_auth, get_added_content,
+                                          get_versions, publish, sync)
 
-from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_REMOTE_PATH,  # noqa
+from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_REMOTE_PATH,
                                                     PYTHON_PYPI_URL, PYTHON_CONTENT_PATH)
-from pulp_python.tests.functional.utils import (gen_publisher, gen_remote,  # noqa
-                                                set_up_module as setUpModule)
+from pulp_python.tests.functional.utils import gen_publisher, gen_remote
+from pulp_python.tests.functional.utils import set_up_module as setUpModule  # noqa:E722
 
 # from pulp_smash.constants import FILE_URL
 

--- a/pulp_python/tests/functional/api/test_crd_publications.py
+++ b/pulp_python/tests/functional/api/test_crd_publications.py
@@ -4,8 +4,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH, DISTRIBUTION_PATH, PUBLICATIONS_PATH
-from pulp_smash.tests.pulp3.utils import get_auth, publish, sync
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
+from pulp_smash.tests.pulp3.utils import gen_distribution, gen_repo, get_auth, publish, sync
 
 from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH)

--- a/pulp_python/tests/functional/api/test_crud_publishers.py
+++ b/pulp_python/tests/functional/api/test_crud_publishers.py
@@ -4,8 +4,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors
 from pulp_smash.tests.pulp3.constants import REPO_PATH
-from pulp_smash.tests.pulp3.utils import get_auth
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import gen_repo, get_auth
 
 from pulp_python.tests.functional.constants import PYTHON_PUBLISHER_PATH
 from pulp_python.tests.functional.utils import gen_publisher

--- a/pulp_python/tests/functional/api/test_crud_remotes.py
+++ b/pulp_python/tests/functional/api/test_crud_remotes.py
@@ -4,8 +4,7 @@ import unittest
 from requests.exceptions import HTTPError
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH
-from pulp_smash.tests.pulp3.utils import get_auth
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import gen_repo, get_auth
 
 from pulp_python.tests.functional.constants import PYTHON_PYPI_URL, PYTHON_REMOTE_PATH
 from pulp_python.tests.functional.utils import gen_remote

--- a/pulp_python/tests/functional/api/test_download_content.py
+++ b/pulp_python/tests/functional/api/test_download_content.py
@@ -6,8 +6,7 @@ from unittest import skip
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import DISTRIBUTION_PATH, REPO_PATH
-from pulp_smash.tests.pulp3.utils import get_auth, sync, publish  # get_content,
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
+from pulp_smash.tests.pulp3.utils import gen_distribution, gen_repo, get_auth, sync, publish
 
 from pulp_python.tests.functional.constants import (PYTHON_PYPI_URL, PYTHON_REMOTE_PATH,
                                                     PYTHON_PUBLISHER_PATH)

--- a/pulp_python/tests/functional/api/test_orphans.py
+++ b/pulp_python/tests/functional/api/test_orphans.py
@@ -5,9 +5,8 @@ from random import choice
 from pulp_smash import api, cli, config, utils
 from pulp_smash.exceptions import CalledProcessError
 from pulp_smash.tests.pulp3.constants import ARTIFACTS_PATH, REPO_PATH
-from pulp_smash.tests.pulp3.utils import (get_auth, get_content, get_versions,
+from pulp_smash.tests.pulp3.utils import (gen_repo, get_auth, get_content, get_versions,
                                           delete_orphans, delete_version, sync)
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 
 
 from pulp_python.tests.functional.constants import (PYTHON_PYPI_URL, PYTHON_REMOTE_PATH,

--- a/pulp_python/tests/functional/api/test_publish.py
+++ b/pulp_python/tests/functional/api/test_publish.py
@@ -6,8 +6,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH
-from pulp_smash.tests.pulp3.utils import get_auth, get_versions, sync, publish
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import gen_repo, get_auth, get_versions, sync, publish
 
 from pulp_python.tests.functional.constants import (PYTHON_CONTENT_PATH, PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH, PYTHON_PUBLISHER_PATH)

--- a/pulp_python/tests/functional/api/test_repo_version.py
+++ b/pulp_python/tests/functional/api/test_repo_version.py
@@ -6,11 +6,9 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH
-from pulp_smash.tests.pulp3.utils import (
-    get_auth, get_artifact_paths, get_content, get_added_content, get_removed_content,
-    get_versions, sync, publish, delete_version
-)
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import (gen_repo, get_auth, get_artifact_paths, get_content,
+                                          get_added_content, get_removed_content, get_versions,
+                                          sync, publish, delete_version)
 
 from pulp_python.tests.functional.constants import (PYTHON_CONTENT_PATH, PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH, PYTHON_PUBLISHER_PATH,

--- a/pulp_python/tests/functional/api/test_sync.py
+++ b/pulp_python/tests/functional/api/test_sync.py
@@ -6,8 +6,7 @@ from pulp_smash import api, config, utils
 
 
 from pulp_smash.tests.pulp3.constants import REPO_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync
+from pulp_smash.tests.pulp3.utils import gen_repo, get_auth, get_content, sync
 
 from pulp_python.tests.functional.constants import (PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH, PYTHON_PACKAGE_COUNT)

--- a/pulp_python/tests/functional/api/test_unlinking_repo.py
+++ b/pulp_python/tests/functional/api/test_unlinking_repo.py
@@ -2,8 +2,7 @@ import unittest
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync, publish
+from pulp_smash.tests.pulp3.utils import gen_repo, get_auth, get_content, sync, publish
 
 from pulp_python.tests.functional.constants import (PYTHON_PUBLISHER_PATH, PYTHON_PYPI_URL,
                                                     PYTHON_REMOTE_PATH)


### PR DESCRIPTION
`gen_distribution` and `gen_repo` are being moved to a different
namespace. Update the functional tests to account for this change.
    
Required PR: https://github.com/PulpQE/pulp-smash/pull/998