### PR TITLE
Make pytest tell why tests skip

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -28,7 +28,7 @@ rq worker -n 'resource_manager@%h' -w 'pulpcore.tasking.worker.PulpWorker' >> ~/
 rq worker -n 'reserved_resource_worker_1@%h' -w 'pulpcore.tasking.worker.PulpWorker' >> ~/reserved_workers-1.log 2>&1 &
 
 sleep 5
-pytest -v -r sx --color=yes --pyargs pulp_python.tests.functional
+pytest -v -r a --color=yes --pyargs pulp_python.tests.functional
 
 if [ $? -ne 0 ]; then
   result=1


### PR DESCRIPTION
When a test skips, pytest doesn't print information about why that test
skipped. For example, if a test contains this line:

    self.skipTest('https://pulp.plan.io/issues/1')

...then pytest does *not* print `https://pulp.plan.io/issues/1` in its
report.

Make pytest print skip messages.