### PR TITLE
PythonPackageContentFilter inherit from core's ContentFilter

### DIFF
--- a/pulp_python/app/viewsets.py
+++ b/pulp_python/app/viewsets.py
@@ -40,7 +40,7 @@ DIST_TYPES = {
 }
 
 
-class PythonPackageContentFilter(platform.BaseFilterSet):
+class PythonPackageContentFilter(platform.ContentFilter):
     """
     FilterSet for PythonPackageContent.
     """


### PR DESCRIPTION
closes #3783
https://pulp.plan.io/issues/3783

Required PR: https://github.com/pulp/pulp/pull/3674