### PR TITLE
Prepend Content model hierarchy with _

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -8,8 +8,6 @@ flake8 --config flake8.cfg || exit 1
 # Run migrations.
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 export PULP_CONTENT_HOST=localhost:8080
-pulp-manager migrate auth --noinput
-pulp-manager makemigrations pulp_app --noinput
 pulp-manager makemigrations pulp_python
 pulp-manager migrate --noinput
 

--- a/pulp_python/app/models.py
+++ b/pulp_python/app/models.py
@@ -140,7 +140,7 @@ class PythonPackageContent(Content):
         """
         Return the artifact id (there is only one for this content type).
         """
-        return self.artifacts.get().pk
+        return self._artifacts.get().pk
 
     def __str__(self):
         """

--- a/pulp_python/app/serializers.py
+++ b/pulp_python/app/serializers.py
@@ -223,7 +223,7 @@ class PythonPackageContentSerializer(core_serializers.ContentSerializer):
         return PythonPackageContent
 
     class Meta:
-        fields = tuple(set(core_serializers.ContentSerializer.Meta.fields) - {'artifacts'}) + (
+        fields = tuple(set(core_serializers.ContentSerializer.Meta.fields) - {'_artifacts'}) + (
             'filename', 'packagetype', 'name', 'version', 'metadata_version', 'summary',
             'description', 'keywords', 'home_page', 'download_url', 'author', 'author_email',
             'maintainer', 'maintainer_email', 'license', 'requires_python', 'project_url',
@@ -239,7 +239,7 @@ class MinimalPythonPackageContentSerializer(PythonPackageContentSerializer):
     """
 
     class Meta:
-        fields = tuple(set(core_serializers.ContentSerializer.Meta.fields) - {'artifacts'}) + (
+        fields = tuple(set(core_serializers.ContentSerializer.Meta.fields) - {'_artifacts'}) + (
             'filename', 'packagetype', 'name', 'version', 'artifact'
         )
         model = python_models.PythonPackageContent

--- a/pulp_python/app/viewsets.py
+++ b/pulp_python/app/viewsets.py
@@ -48,7 +48,6 @@ class PythonPackageContentFilter(platform.ContentFilter):
     class Meta:
         model = python_models.PythonPackageContent
         fields = {
-            'type': ['exact', 'in'],
             'name': ['exact', 'in'],
             'author': ['exact', 'in'],
             'packagetype': ['exact', 'in'],

--- a/pulp_python/tests/functional/constants.py
+++ b/pulp_python/tests/functional/constants.py
@@ -8,7 +8,7 @@ from pulp_smash.pulp3.constants import (
 )
 
 
-PYTHON_CONTENT_NAME = 'python'
+PYTHON_CONTENT_NAME = 'pulp_python.python'
 
 PYTHON_CONTENT_PATH = urljoin(CONTENT_PATH, 'python/packages/')
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'pulpcore-plugin==0.1.0b14',
+    'pulpcore-plugin==0.1.0b16',
     'pkginfo',
     'packaging',
 ]


### PR DESCRIPTION
Prepend all pulpcore model fields in the Content model hierarchy with _
and do the same for all plugins reliant on them.

Required PR: https://github.com/pulp/pulp/pull/3798

re #4206
https://pulp.plan.io/issues/4206