### PR TITLE
updated the documentation link. fixes #4154

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,5 +10,5 @@ pulp_python
 A Pulp plugin to support hosting your own pip compatible Python packages.
 
 For more information, please see the `documentation
-<http://pulp-python.readthedocs.io/en/3.0-dev/>`_ or the `Pulp project page
+<https://pulp-python.readthedocs.io/en/latest/>`_ or the `Pulp project page
 <https://pulpproject.org>`_.


### PR DESCRIPTION
The readme pointed to https://pulp-python.readthedocs.io/en/3.0-dev/

This versions includes a note: "You are not reading the most recent version of this documentation. 3.0.0b1 is the latest version available."

So I updated the link to the latest release.