### PR TITLE
Use base serializer to create ContentArtifacts

### DIFF
--- a/pulp_python/app/serializers.py
+++ b/pulp_python/app/serializers.py
@@ -203,14 +203,15 @@ class PythonPackageContentSerializer(core_serializers.SingleArtifactContentSeria
         """
         classifiers = validated_data.pop('classifiers')
 
-        PythonPackageContent = python_models.PythonPackageContent.objects.create(**validated_data)
+        package_content = super().create(validated_data)
+
         for classifier in classifiers:
             python_models.Classifier.objects.create(
-                python_package_content=PythonPackageContent,
+                python_package_content=package_content,
                 **classifier
             )
 
-        return PythonPackageContent
+        return package_content
 
     class Meta:
         fields = core_serializers.SingleArtifactContentSerializer.Meta.fields + (

--- a/pulp_python/app/viewsets.py
+++ b/pulp_python/app/viewsets.py
@@ -11,7 +11,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from pulpcore.plugin import viewsets as platform
-from pulpcore.plugin.models import Artifact, ContentArtifact, RepositoryVersion
+from pulpcore.plugin.models import Artifact, RepositoryVersion
 from pulpcore.plugin.serializers import (
     AsyncOperationResponseSerializer,
     RepositoryPublishURLSerializer,
@@ -108,18 +108,11 @@ class PythonPackageContentViewSet(platform.ContentViewSet):
         data['version'] = metadata.version
         data['filename'] = filename
         data['_artifact'] = request.data['_artifact']
+        data['_relative_path'] = filename
 
         serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
-        serializer.validated_data.pop('_artifact')
-        content = serializer.save()
-
-        if content.pk:
-            ContentArtifact.objects.create(
-                artifact=artifact,
-                content=content,
-                relative_path=filename
-            )
+        serializer.save()
 
         headers = self.get_success_headers(request.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'pulpcore-plugin>=0.1.0b18',
+    'pulpcore-plugin>=0.1.0b21',
     'pkginfo',
     'packaging',
 ]


### PR DESCRIPTION
SingleArtifactSerializer was updated to handle ContentArtifacts so each
plugin doesn't need to.

Hashtag: @CodeHeeler ty 100 times

https://pulp.plan.io/issues/4451
fixes #4451