### PR TITLE
Remove pulp-manager and return to django-admin

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -8,15 +8,15 @@ flake8 --config flake8.cfg || exit 1
 # Run migrations.
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 export PULP_CONTENT_HOST=localhost:8080
-pulp-manager makemigrations python
-pulp-manager migrate --noinput
+django-admin makemigrations python
+django-admin migrate --noinput
 
 # Run unit tests.
 (cd ../pulpcore && coverage run manage.py test pulp_python.tests.unit)
 
 # Run functional tests.
-pulp-manager reset-admin-password --password admin
-pulp-manager runserver >> ~/django_runserver.log 2>&1 &
+django-admin reset-admin-password --password admin
+django-admin runserver >> ~/django_runserver.log 2>&1 &
 gunicorn pulpcore.content:server --bind 'localhost:8080' --worker-class 'aiohttp.GunicornWebWorker' -w 2 >> ~/content_app.log 2>&1 &
 rq worker -n 'resource-manager@%h' -w 'pulpcore.tasking.worker.PulpWorker' >> ~/resource_manager.log 2>&1 &
 rq worker -n 'reserved-resource-worker-1@%h' -w 'pulpcore.tasking.worker.PulpWorker' >> ~/reserved_worker-1.log 2>&1 &


### PR DESCRIPTION
pulp-manager is not needed, use django-admin directly

re: #4450
https://pulp.plan.io/issues/4450