### PR TITLE
Update distribution creation to use task_handler

### DIFF
--- a/pulp_python/tests/functional/api/test_download_content.py
+++ b/pulp_python/tests/functional/api/test_download_content.py
@@ -81,10 +81,10 @@ class DownloadContentTestCase(unittest.TestCase):
         # Create a distribution.
         body = gen_distribution()
         body['publication'] = publication['_href']
-        response_dict = client.post(DISTRIBUTION_PATH, body)
-        dist_task = client.get(response_dict['task'])
-        distribution_href = dist_task['created_resources'][0]
-        distribution = client.get(distribution_href)
+        distribution = client.using_handler(api.task_handler).post(
+            DISTRIBUTION_PATH,
+            body
+        )
         self.addCleanup(client.delete, distribution['_href'])
 
         # Pick a file, and download it from both Pulp Fixtures…

--- a/pulp_python/tests/functional/api/test_sync.py
+++ b/pulp_python/tests/functional/api/test_sync.py
@@ -235,7 +235,7 @@ class PrereleasesTestCase(unittest.TestCase):
         self.client.patch(self.remote['_href'], body)
         type(self).remote = self.client.get(self.remote['_href'])
 
-        sync(self.cfg, self.remote, self.repo)
+        sync(self.cfg, self.remote, self.repo, mirror=True)
         type(self).repo = self.client.get(self.repo['_href'])
 
         self.assertDictEqual(
@@ -329,7 +329,7 @@ class IncludesExcludesTestCase(unittest.TestCase):
         self.client.patch(self.remote['_href'], body)
         type(self).remote = self.client.get(self.remote['_href'])
 
-        sync(self.cfg, self.remote, self.repo)
+        sync(self.cfg, self.remote, self.repo, mirror=True)
         type(self).repo = self.client.get(self.repo['_href'])
 
         self.assertEqual(
@@ -357,7 +357,7 @@ class IncludesExcludesTestCase(unittest.TestCase):
         self.client.patch(self.remote['_href'], body)
         type(self).remote = self.client.get(self.remote['_href'])
 
-        sync(self.cfg, self.remote, self.repo)
+        sync(self.cfg, self.remote, self.repo, mirror=True)
         type(self).repo = self.client.get(self.repo['_href'])
 
         self.assertEqual(


### PR DESCRIPTION
Distribution creation was modified to be an async task.
A new response_handler was added to pulp-smash to deal with those cases.
Update distribution creation to use this new response_handler

'[noissue]'