### PR TITLE
Link to the newly published API docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,10 +15,6 @@ Community contributions are encouraged.
 * View and file issues in the `Redmine Tracker
   <https://pulp.plan.io/projects/pulp_python/issues>`_.
 
-REST API
---------
-
-REST API documentation for this plugin can be found `here <restapi.html>`_
 
 Table of Contents
 -----------------
@@ -28,6 +24,7 @@ Table of Contents
 
    installation
    workflows/index
+   restapi/index
    release-notes/3.0.z.rst
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,8 +1,14 @@
 User Setup
 ==========
 
-Install pulp-python
--------------------
+Ansible Installer (Recommended)
+-------------------------------
+
+We recommend that you install `pulpcore` and `pulp-python` together using the `Ansible installer
+<https://github.com/pulp/ansible-pulp/blob/master/README.md>`_.
+
+Pip Install
+-----------
 
 This document assumes that you have
 `installed pulpcore <https://docs.pulpproject.org/en/3.0/nightly/installation/instructions.html>`_

--- a/docs/restapi/index.rst
+++ b/docs/restapi/index.rst
@@ -1,0 +1,9 @@
+REST API
+========
+
+Pulpcore Reference: `pulpcore REST documentation <https://docs.pulpproject.org/en/3.0/nightly/restapi.html>`_.
+
+Pulp Python Endpoints
+---------------------
+
+Pulp Python Reference `pulp-python REST documentation <../restapi.html>`_

--- a/docs/workflows/publish-host.rst
+++ b/docs/workflows/publish-host.rst
@@ -23,6 +23,8 @@ Create a variable for convenience.::
 
 $ export PUBLISHER_HREF=$(http $BASE_ADDR/pulp/api/v3/publishers/python/python/ | jq -r '.results[] | select(.name == "bar") | ._href')
 
+Reference: `Python Publisher API Usage <../restapi.html#tag/publishers>`_
+
 
 Publish a repository with a publisher
 -------------------------------------
@@ -45,6 +47,8 @@ Create a variable for convenience.::
 
 $ export PUBLICATION_HREF=$(http $BASE_ADDR/pulp/api/v3/publications/ | jq -r --arg PUBLISHER_HREF "$PUBLISHER_HREF" '.results[] | select(.publisher==$PUBLISHER_HREF) | ._href')
 
+Reference: `Python Publish Task Usage <../restapi.html#operation/publishers_python_python_publish>`_
+
 Host a Publication (Create a Distribution)
 --------------------------------------------
 
@@ -60,6 +64,9 @@ Response::
         "_href": "/pulp/api/v3/distributions/1/",
        ...
     }
+
+Reference (pulpcore): `Distribution API Usage
+<https://docs.pulpproject.org/en/3.0/nightly/restapi.html#tag/distributions>`_
 
 .. _using-distributions:
 

--- a/docs/workflows/sync.rst
+++ b/docs/workflows/sync.rst
@@ -22,6 +22,9 @@ If you want to copy/paste your way through the guide, create an environment vari
 
     $ export REPO_HREF=$(http $BASE_ADDR/pulp/api/v3/repositories/ | jq -r '.results[] | select(.name == "foo") | ._href')
 
+Reference (pulpcore): `Repository API Usage
+<https://docs.pulpproject.org/en/3.0/nightly/restapi.html#tag/repositories>`_
+
 
 Create a Remote
 ---------------
@@ -101,6 +104,9 @@ You can also use version specifiers to "exclude" certain versions of a project, 
             },
         ]'
 
+Reference: `Python Remote Usage
+<https://pulp-python.readthedocs.io/en/latest/restapi.html#tag/remotes>`_
+
 Sync repository foo with remote
 -------------------------------
 
@@ -161,3 +167,6 @@ Response::
         "state": "completed",
         "worker": "/pulp/api/v3/workers/eaffe1be-111a-421d-a127-0b8fa7077cf7/"
     }
+
+Reference: `Python sync
+<https://pulp-python.readthedocs.io/en/latest/restapi.html#operation/remotes_python_python_sync>`_

--- a/docs/workflows/upload.rst
+++ b/docs/workflows/upload.rst
@@ -19,6 +19,8 @@ Create a variable for convenience::
 
     $ export REPO_HREF=$(http $BASE_ADDR/pulp/api/v3/repositories/ | jq -r '.results[] | select(.name == "foo") | ._href')
 
+Reference (pulpcore): `Repository API Usage
+<https://docs.pulpproject.org/en/3.0/nightly/restapi.html#tag/repositories>`_
 
 Upload a file to Pulp
 ---------------------
@@ -34,6 +36,9 @@ Response::
         ...
     }
 
+
+Reference (pulpcore): `Artifact API Usage
+<https://docs.pulpproject.org/en/3.0/nightly/restapi.html#tag/artifacts>`_
 
 Create content from an artifact
 -------------------------------
@@ -57,9 +62,14 @@ Create a variable for convenience::
 
     $ export CONTENT_HREF=$(http $BASE_ADDR/pulp/api/v3/content/python/packages/ | jq -r '.results[] | select(.filename == "shelf_reader-0.1-py2-none-any.whl") | ._href')
 
+Reference: `Python Content API Usage <../restapi.html#tag/content>`_
+
 Add content to a repository
 ---------------------------
 
 Once there is a content unit, it can be added and removed and from to repositories::
 
 $ http POST $BASE_ADDR$REPO_HREF'versions/' add_content_units:="[\"$CONTENT_HREF\"]"
+
+Reference (pulpcore): `Repository Version Creation API Usage
+<https://docs.pulpproject.org/en/3.0/nightly/restapi.html#operation/repositories_versions_create>`_


### PR DESCRIPTION
Adding these reference links should make the user experience more
smooth, particularly when navigating both pulp-python and pulpcore docs.
[noissue]