### PR TITLE
First fix for pip install issue #6792

### DIFF
--- a/CHANGES/6792.doc
+++ b/CHANGES/6792.doc
@@ -1,0 +1,1 @@
+﻿Added "index.html" to the relative_path field for both project_metadata and index_metadata. Added a "/" to fix the link in the simple_index_template. 

--- a/pulp_python/app/tasks/publish.py
+++ b/pulp_python/app/tasks/publish.py
@@ -22,7 +22,7 @@ simple_index_template = """<!DOCTYPE html>
   </head>
   <body>
     {% for name, canonical_name in projects %}
-    <a href="{{ canonical_name }}">{{ name }}</a><br/>
+    <a href="{{ canonical_name }}/">{{ name }}</a><br/>
     {% endfor %}
   </body>
 </html>
@@ -101,7 +101,7 @@ def write_simple_api(publication):
         index.write(template.render(context))
 
     index_metadata = models.PublishedMetadata.create_from_file(
-        relative_path=simple_dir,
+        relative_path=index_path,
         publication=publication,
         file=File(open(index_path, 'rb'))
     )
@@ -140,7 +140,7 @@ def write_simple_api(publication):
             simple_metadata.write(template.render(context))
 
         project_metadata = models.PublishedMetadata.create_from_file(
-            relative_path=project_dir,
+            relative_path=metadata_relative_path,
             publication=publication,
             file=File(open(metadata_relative_path, 'rb'))
         )


### PR DESCRIPTION
Fixed published metadata relative_path names for the index and project metadata that was causing the pulp contentapp to incorrectly render the wrong html.
Contentapp still incorrectly sets the html's headers causing pip install to fail with the following: 

> > Downloading http://pulp3-source-fedora31.localhost.example.com/pulp/content/foo/simple/ (202 bytes)
>   ERROR: Cannot unpack file /tmp/pip-unpack-qbmyk3ej/simple.bin (downloaded from /tmp/pip-req-build-or9d4dk4, content-type: application/octet-stream); cannot detect archive format
> ERROR: Cannot determine archive format of /tmp/pip-req-build-or9d4dk4

ref #6792
https://pulp.plan.io/issues/6792