### PR TITLE
Enabling Remote Tests

### DIFF
--- a/CHANGES/remotetests.misc
+++ b/CHANGES/remotetests.misc
@@ -1,0 +1,1 @@
+Remove the skip on the UpdateRemoteWithInvalidProjectSpecifiers test cases.  Modified them to check for an HTTPError instead of a task failure.

--- a/pulp_python/tests/functional/api/test_crud_remotes.py
+++ b/pulp_python/tests/functional/api/test_crud_remotes.py
@@ -35,13 +35,13 @@ class CRUDRemotesTestCase(unittest.TestCase):
         """
         body = _gen_verbose_remote()
         type(self).remote = self.client.post(PYTHON_REMOTE_PATH, body)
-        for key in ('username', 'password'):
+        for key in ("username", "password"):
             del body[key]
         for key, val in body.items():
             with self.subTest(key=key):
                 self.assertEqual(self.remote[key], val)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_02_create_same_name(self):
         """
         Try to create a second remote with an identical name.
@@ -50,69 +50,67 @@ class CRUDRemotesTestCase(unittest.TestCase):
         <https://github.com/PulpQE/pulp-smash/issues/1055>`_.
         """
         body = _gen_verbose_remote()
-        body['name'] = self.remote['name']
+        body["name"] = self.remote["name"]
         with self.assertRaises(HTTPError):
             self.client.post(PYTHON_REMOTE_PATH, body)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_02_read_remote(self):
         """
         Read a remote by its href.
         """
-        remote = self.client.get(self.remote['pulp_href'])
+        remote = self.client.get(self.remote["pulp_href"])
         for key, val in self.remote.items():
             with self.subTest(key=key):
                 self.assertEqual(remote[key], val)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_02_read_remotes(self):
         """
         Read a remote by its name.
         """
-        page = self.client.get(PYTHON_REMOTE_PATH, params={
-            'name': self.remote['name']
-        })
-        self.assertEqual(len(page['results']), 1)
+        page = self.client.get(PYTHON_REMOTE_PATH, params={"name": self.remote["name"]})
+        self.assertEqual(len(page["results"]), 1)
         for key, val in self.remote.items():
             with self.subTest(key=key):
-                self.assertEqual(page['results'][0][key], val)
+                self.assertEqual(page["results"][0][key], val)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_03_partially_update(self):
         """
         Update a remote using HTTP PATCH.
         """
         body = _gen_verbose_remote()
-        self.client.patch(self.remote['pulp_href'], body)
-        for key in ('username', 'password'):
+        self.client.patch(self.remote["pulp_href"], body)
+        for key in ("username", "password"):
             del body[key]
-        type(self).remote = self.client.get(self.remote['pulp_href'])
+        type(self).remote = self.client.get(self.remote["pulp_href"])
         for key, val in body.items():
             with self.subTest(key=key):
                 self.assertEqual(self.remote[key], val)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_04_fully_update(self):
         """
         Update a remote using HTTP PUT.
         """
         body = _gen_verbose_remote()
-        self.client.put(self.remote['pulp_href'], body)
-        for key in ('username', 'password'):
+        self.client.put(self.remote["pulp_href"], body)
+        for key in ("username", "password"):
             del body[key]
-        type(self).remote = self.client.get(self.remote['pulp_href'])
+        type(self).remote = self.client.get(self.remote["pulp_href"])
         for key, val in body.items():
             with self.subTest(key=key):
                 self.assertEqual(self.remote[key], val)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_05_delete(self):
         """
         Delete a remote.
         """
-        self.client.delete(self.remote['pulp_href'])
+        self.client.delete(self.remote["pulp_href"])
         with self.assertRaises(HTTPError):
-            self.client.get(self.remote['pulp_href'])
+            self.client.get(self.remote["pulp_href"])
 
 
 class CreateRemoteNoURLTestCase(unittest.TestCase):
@@ -131,7 +129,7 @@ class CreateRemoteNoURLTestCase(unittest.TestCase):
 
         """
         body = gen_python_remote(utils.uuid4())
-        del body['url']
+        del body["url"]
         with self.assertRaises(HTTPError):
             api.Client(config.get_config()).post(PYTHON_REMOTE_PATH, body)
 
@@ -149,11 +147,13 @@ def _gen_verbose_remote():
 
     """
     attrs = gen_python_remote()
-    attrs.update({
-        'password': utils.uuid4(),
-        'policy': random.choice(ON_DEMAND_DOWNLOAD_POLICIES),
-        'username': utils.uuid4(),
-    })
+    attrs.update(
+        {
+            "password": utils.uuid4(),
+            "policy": random.choice(ON_DEMAND_DOWNLOAD_POLICIES),
+            "username": utils.uuid4(),
+        }
+    )
     return attrs
 
 
@@ -222,9 +222,9 @@ class CreateRemoteWithNoVersionTestCase(unittest.TestCase):
         """
         body = gen_python_remote(includes=PYTHON_VALID_SPECIFIER_NO_VERSION)
         remote = self.client.post(PYTHON_REMOTE_PATH, body)
-        self.addCleanup(self.client.delete, remote['pulp_href'])
+        self.addCleanup(self.client.delete, remote["pulp_href"])
 
-        self.assertEqual(remote['includes'][0]['version_specifier'], "")
+        self.assertEqual(remote["includes"][0]["version_specifier"], "")
 
     def test_excludes_with_no_version(self):
         """
@@ -232,12 +232,11 @@ class CreateRemoteWithNoVersionTestCase(unittest.TestCase):
         """
         body = gen_python_remote(excludes=PYTHON_VALID_SPECIFIER_NO_VERSION)
         remote = self.client.post(PYTHON_REMOTE_PATH, body)
-        self.addCleanup(self.client.delete, remote['pulp_href'])
+        self.addCleanup(self.client.delete, remote["pulp_href"])
 
-        self.assertEqual(remote['includes'][0]['version_specifier'], "")
+        self.assertEqual(remote["includes"][0]["version_specifier"], "")
 
 
-@unittest.skip("Broken due to potential DRF issue?")
 class UpdateRemoteWithInvalidProjectSpecifiersTestCase(unittest.TestCase):
     """
     Test that updating a remote with an invalid project specifier fails non-destructively.
@@ -259,44 +258,38 @@ class UpdateRemoteWithInvalidProjectSpecifiersTestCase(unittest.TestCase):
         """
         Clean class-wide variable.
         """
-        cls.client.delete(cls.remote['pulp_href'])
+        cls.client.delete(cls.remote["pulp_href"])
 
+    @unittest.skip("Broken due to potential DRF issue?")
     def test_includes_with_no_name(self):
         """
         Test an include specifier without a "name" field.
         """
         body = {"includes": PYTHON_INVALID_SPECIFIER_NO_NAME}
-        task_href = self.client.patch(self.remote['pulp_href'], body)
-        update_task = (task for task in api.poll_task(self.cfg, task_href))[0]
-        self.assertEqual(update_task['state'], 'failed')
-        self.assertDictEqual(self.client.get(self.remote['pulp_href']), self._original_remote)
+        with self.assertRaises(HTTPError):
+            self.client.patch(self.remote["pulp_href"], body)
 
     def test_includes_with_bad_version(self):
         """
         Test an include specifier with an invalid "version_specifier" field value.
         """
         body = {"includes": PYTHON_INVALID_SPECIFIER_BAD_VERSION}
-        task_href = self.client.patch(self.remote['pulp_href'], body)
-        update_task = (task for task in api.poll_task(self.cfg, task_href))[0]
-        self.assertEqual(update_task['state'], 'failed')
-        self.assertDictEqual(self.client.get(self.remote['pulp_href']), self._original_remote)
+        with self.assertRaises(HTTPError):
+            self.client.patch(self.remote["pulp_href"], body)
 
+    @unittest.skip("Broken due to potential DRF issue?")
     def test_excludes_with_no_name(self):
         """
         Test an exclude specifier without a "name" field.
         """
         body = {"excludes": PYTHON_INVALID_SPECIFIER_NO_NAME}
-        task_href = self.client.patch(self.remote['pulp_href'], body)
-        update_task = (task for task in api.poll_task(self.cfg, task_href))[0]
-        self.assertEqual(update_task['state'], 'failed')
-        self.assertDictEqual(self.client.get(self.remote['pulp_href']), self._original_remote)
+        with self.assertRaises(HTTPError):
+            self.client.patch(self.remote["pulp_href"], body)
 
     def test_excludes_with_bad_version(self):
         """
         Test an exclude specifier with an invalid "version_specifier" field value.
         """
         body = {"excludes": PYTHON_INVALID_SPECIFIER_BAD_VERSION}
-        task_href = self.client.patch(self.remote['pulp_href'], body)
-        update_task = (task for task in api.poll_task(self.cfg, task_href))[0]
-        self.assertEqual(update_task['state'], 'failed')
-        self.assertDictEqual(self.client.get(self.remote['pulp_href']), self._original_remote)
+        with self.assertRaises(HTTPError):
+            self.client.patch(self.remote["pulp_href"], body)


### PR DESCRIPTION
Modified remote tests to check for HTTP errors when invalid specifiers are sent to update remote include/excludes.  Two tests are still skipped due to 6863.

ref #6863
https://pulp.plan.io/issues/6863