### PR TITLE
Moved requirements to 'requirements.txt'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pulpcore>=3.4
+pkginfo
+packaging

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,8 @@
 
 from setuptools import setup, find_packages
 
-requirements = [
-    'pulpcore>=3.4',
-    'pkginfo',
-    'packaging',
-]
+with open("requirements.txt") as requirements:
+    requirements = requirements.readlines()
 
 with open('README.rst') as f:
     long_description = f.read()


### PR DESCRIPTION
Moved the requirements needed for pulp_python into the file 'requirements.txt' for the release script.  Changed setup.py to read from that file.

[noissue]