### PR TITLE
Remote from Bandersnatch config feature

### DIFF
--- a/CHANGES/6929.feature
+++ b/CHANGES/6929.feature
@@ -1,0 +1,1 @@
+Added a new endpoint to remotes "/from_bandersnatch" that allows for Python remote creation from a Bandersnatch config file.

--- a/pulp_python/app/serializers.py
+++ b/pulp_python/app/serializers.py
@@ -255,6 +255,7 @@ class PythonRemoteSerializer(core_serializers.RemoteSerializer):
         help_text=_(
             "A JSON list containing project specifiers for Python packages to exclude."
         ),
+
     )
     prereleases = serializers.BooleanField(
         required=False,
@@ -274,7 +275,7 @@ class PythonRemoteSerializer(core_serializers.RemoteSerializer):
                 Requirement.parse(pkg)
             except ValueError as ve:
                 raise serializers.ValidationError(
-                    _("includes specifier {} is invalid\n {}".format(pkg, ve))
+                    _("includes specifier {} is invalid. {}".format(pkg, ve))
                 )
         return value
 
@@ -285,7 +286,7 @@ class PythonRemoteSerializer(core_serializers.RemoteSerializer):
                 Requirement.parse(pkg)
             except ValueError as ve:
                 raise serializers.ValidationError(
-                    _("excludes specifier {} is invalid\n {}".format(pkg, ve))
+                    _("excludes specifier {} is invalid. {}".format(pkg, ve))
                 )
         return value
 
@@ -294,6 +295,22 @@ class PythonRemoteSerializer(core_serializers.RemoteSerializer):
             "includes", "excludes", "prereleases"
         )
         model = python_models.PythonRemote
+
+
+class PythonBanderRemoteSerializer(serializers.Serializer):
+    """
+    A Serializer for the initial step of creating a Python Remote from a Bandersnatch config file
+    """
+
+    config = serializers.FileField(
+        help_text=_("A Bandersnatch config that may be used to construct a Python Remote."),
+        required=True,
+        write_only=True,
+    )
+    name = serializers.CharField(
+        help_text=_("A unique name for this remote"),
+        required=True,
+    )
 
 
 class PythonPublicationSerializer(core_serializers.PublicationSerializer):

--- a/pulp_python/tests/functional/constants.py
+++ b/pulp_python/tests/functional/constants.py
@@ -178,3 +178,57 @@ PYTHON_LARGE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "python_large/")
 # FIXME: replace this with the actual number of content units in your test fixture
 PYTHON_LARGE_FIXTURE_COUNT = 25
 """The number of content units available at :data:`PYTHON_LARGE_FIXTURE_URL`."""
+
+DEFAULT_BANDER_REMOTE_BODY = {
+    "url": "https://pypi.org",
+    "download_concurrency": 3,
+    "policy": "immediate",
+    "prereleases": True,
+    "excludes": ["example1", "example2"]
+}
+
+BANDERSNATCH_CONF = b"""
+[mirror]
+; The directory where the mirror data will be stored.
+directory = /srv/pypi
+; Save JSON metadata into the web tree:
+json = false
+
+; scheme for PyPI server MUST be https
+master = https://pypi.org
+
+; The network socket timeout to use for all connections.
+timeout = 10
+global-timeout = 18000
+
+; Number of worker threads to use for parallel downloads.
+workers = 3
+
+; Whether to hash package indexes
+hash-index = false
+
+; Whether to stop a sync quickly after an error is found or whether to continue
+; syncing but not marking the sync as successful.
+stop-on-error = false
+
+storage-backend = filesystem
+
+; Number of consumers which verify metadata
+verifiers = 3
+
+; Configure a file to write out the list of files downloaded during the mirror.
+diff-file = {{mirror_directory}}/mirrored-files
+diff-append-epoch = false
+
+; Enable filtering plugins
+[plugins]
+; Enable all or specific plugins - e.g. whitelist_project
+enabled = all
+
+[blacklist]
+; List of PyPI packages not to sync - Useful if malicious packages are mirrored
+packages =
+    example1
+    example2
+
+"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pulpcore>=3.4
 pkginfo
 packaging
 requirements-parser
+bandersnatch


### PR DESCRIPTION
New endpoint /from_bandersnatch/ for /remotes/python/python/ that creates a Python remote through uploading a Bandersnatch config

https://pulp.plan.io/issues/6929