### PR TITLE
Fix includes parameter in docs example

### DIFF
--- a/docs/_scripts/remote.sh
+++ b/docs/_scripts/remote.sh
@@ -2,7 +2,7 @@
 http POST $BASE_ADDR/pulp/api/v3/remotes/python/python/ \
     name='bar' \
     url='https://pypi.org/' \
-    includes:='[{"name": "shelf-reader"}]'
+    includes:='["shelf-reader"]'
 
 # Export an environment variable for the new remote URI.
 export REMOTE_HREF=$(http $BASE_ADDR/pulp/api/v3/remotes/python/python/ \


### PR DESCRIPTION
# Issue

while follwing the docs to create my first pulp python repo, I encountered the following issue:

```
$ http -a admin:admin PATCH $BASE_ADDR$REMOTE_HREF includes='[{"name": "shelf-reader"}]'
HTTP/1.1 400 Bad Request
Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
Connection: keep-alive
Content-Length: 93
Content-Type: application/json
Date: Wed, 19 Aug 2020 14:43:07 GMT
Server: nginx/1.18.0
Vary: Accept, Cookie
X-Frame-Options: SAMEORIGIN

{
    "includes": [
        "includes specifier [ is invalid. Invalid requirement, parse error at \"'['\""
    ]
}
```

```
$ docker logs pulp
pulp: django.request:ERROR: Internal Server Error: /pulp/api/v3/remotes/python/python/4f0810db-efd9-400a-99f2-02e1b110aa43/
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/rest_framework/viewsets.py", line 114, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/rest_framework/views.py", line 505, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python3.7/site-packages/rest_framework/views.py", line 465, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.7/site-packages/rest_framework/views.py", line 476, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.7/site-packages/rest_framework/views.py", line 502, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pulpcore/app/viewsets/base.py", line 434, in partial_update
    return self.update(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pulpcore/app/viewsets/base.py", line 418, in update
    serializer.is_valid(raise_exception=True)
  File "/usr/local/lib/python3.7/site-packages/rest_framework/serializers.py", line 235, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/usr/local/lib/python3.7/site-packages/rest_framework/serializers.py", line 430, in run_validation
    value = self.to_internal_value(data)
  File "/usr/local/lib/python3.7/site-packages/rest_framework/serializers.py", line 489, in to_internal_value
    validated_value = validate_method(validated_value)
  File "/usr/local/lib/python3.7/site-packages/pulp_python/app/serializers.py", line 275, in validate_includes
    Requirement.parse(pkg)
  File "/usr/local/lib/python3.7/site-packages/requirements/requirement.py", line 214, in parse
    if line.startswith('-e') or line.startswith('--editable'):
AttributeError: 'dict' object has no attribute 'startswith'
```

# Fix
use list of strings instead of list of dicts for the includes parameter
```
$ http -a admin:admin PATCH $BASE_ADDR$REMOTE_HREF includes='["shelf-reader"]'
```