### PR TITLE
Added 'policy' field to remote creation from Bandersnatch config

### DIFF
--- a/CHANGES/7331.bugfix
+++ b/CHANGES/7331.bugfix
@@ -1,0 +1,1 @@
+Policy can now be specified when creating a remote from a Bandersnatch config

--- a/pulp_python/app/serializers.py
+++ b/pulp_python/app/serializers.py
@@ -312,6 +312,13 @@ class PythonBanderRemoteSerializer(serializers.Serializer):
         required=True,
     )
 
+    policy = serializers.ChoiceField(
+        help_text=_("The policy to use when downloading content. The possible values include: "
+                    "'immediate', 'on_demand', and 'cache_only'. 'immediate' is the default."),
+        choices=core_models.Remote.POLICY_CHOICES,
+        default=core_models.Remote.IMMEDIATE
+    )
+
 
 class PythonPublicationSerializer(core_serializers.PublicationSerializer):
     """

--- a/pulp_python/app/viewsets.py
+++ b/pulp_python/app/viewsets.py
@@ -149,8 +149,10 @@ class PythonRemoteViewSet(core_viewsets.RemoteViewSet):
         serializer.is_valid(raise_exception=True)
         bander_config_file = serializer.validated_data.get("config")
         name = serializer.validated_data.get("name")
+        policy = serializer.validated_data.get("policy")
         bander_config = BandersnatchConfig(bander_config_file.file.name).config
         data = {"name": name,
+                "policy": policy,
                 "url": bander_config.get("mirror", "master"),
                 "download_concurrency": bander_config.get("mirror", "workers"),
                 }

--- a/pulp_python/tests/functional/api/test_crud_remotes.py
+++ b/pulp_python/tests/functional/api/test_crud_remotes.py
@@ -116,6 +116,7 @@ class CreateRemoteFromBandersnatchConfig(unittest.TestCase):
     This test targets the following issues:
 
     * `Pulp #6929 <https://pulp.plan.io/issues/6929>`_
+    * `Pulp #7331 <https://pulp.plan.io/issues/7331>`_
     """
 
     def test_01_creation(self):
@@ -128,6 +129,21 @@ class CreateRemoteFromBandersnatchConfig(unittest.TestCase):
             remote = remote_api.from_bandersnatch(config.name, name)
             self.addCleanup(remote_api.delete, remote.pulp_href)
             expected = _gen_expected_remote_body(name)
+            for key, val in expected.items():
+                with self.subTest(key=key):
+                    self.assertEqual(remote.to_dict()[key], val, key)
+
+    def test_02_ondemand(self):
+        """Create a remote from Bandersnatch config w/ policy remote"""
+        remote_api = RemotesPythonApi(gen_python_client())
+        with NamedTemporaryFile() as config:
+            config.write(BANDERSNATCH_CONF)
+            config.seek(0)
+            name = utils.uuid4()
+            policy = "on_demand"
+            remote = remote_api.from_bandersnatch(config.name, name, policy=policy)
+            self.addCleanup(remote_api.delete, remote.pulp_href)
+            expected = _gen_expected_remote_body(name, policy=policy)
             for key, val in expected.items():
                 with self.subTest(key=key):
                     self.assertEqual(remote.to_dict()[key], val, key)


### PR DESCRIPTION
fixes: #7331
https://pulp.plan.io/issues/7331