### PR TITLE
Fixed readme rendering for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-pulp_python
-===========
+# pulp_python
 
-[![Pulp CI](https://github.com/pulp/pulp_python/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/pulp/pulp_python/actions/workflows/ci.yml)
+![Pulp CI](https://github.com/pulp/pulp_python/actions/workflows/ci.yml/badge.svg?branch=master)
 
-[![Pulp Nightly CI/CD](https://github.com/pulp/pulp_python/actions/workflows/nightly.yml/badge.svg)](https://github.com/pulp/pulp_python/actions/workflows/nightly.yml)
+![Pulp Nightly CI/CD](https://github.com/pulp/pulp_python/actions/workflows/nightly.yml/badge.svg)
 
 A Pulp plugin to support hosting your own pip compatible Python packages.
 


### PR DESCRIPTION
If you go to our [PyPI](https://pypi.org/project/pulp-python/) you'll see the project description isn't rendering correctly.  [Pulp deb](https://pypi.org/project/pulp-deb/) also uses a [README.md](https://github.com/pulp/pulp_deb/blob/main/README.md) and theirs renders properly on GitHub and PyPI, so I copied the notation they use.