### PR TITLE
Fix proxy url not being passed during sync

### DIFF
--- a/CHANGES/436.bugfix
+++ b/CHANGES/436.bugfix
@@ -1,0 +1,2 @@
+Fixed proxy url not being passed during sync
+(backported from #433)

--- a/pulp_python/app/tasks/sync.py
+++ b/pulp_python/app/tasks/sync.py
@@ -112,8 +112,6 @@ class PythonBanderStage(Stage):
             environ['http_proxy'] = self.remote.proxy_url
         # local & global timeouts defaults to 10secs and 5 hours
         async with Master(self.remote.url) as master:
-            if self.remote.proxy_url:
-                environ.pop('http_proxy')
             deferred_download = self.remote.policy != Remote.IMMEDIATE
             workers = self.remote.download_concurrency or self.remote.DEFAULT_DOWNLOAD_CONCURRENCY
             async with ProgressReport(


### PR DESCRIPTION
backports: #433

fixes #436

(cherry picked from commit 35ca2819aa392ddd711022a076edfbe43aa8010d)