### PR TITLE
Add simple page parsing for full syncs

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -71,7 +71,7 @@ services:
 VARSYAML
 
 cat >> vars/main.yaml << VARSYAML
-pulp_settings: {"orphan_protection_time": 0}
+pulp_settings: {"orphan_protection_time": 0, "pypi_api_hostname": "https://pulp:443"}
 pulp_scheme: https
 
 pulp_container_tag: https

--- a/CHANGES/462.feature
+++ b/CHANGES/462.feature
@@ -1,0 +1,1 @@
+Added ability to fully sync repositories that don't support the PyPI XMLRPC endpoints. Full Pulp-to-Pulp syncing is now available.

--- a/docs/tech-preview.rst
+++ b/docs/tech-preview.rst
@@ -6,6 +6,6 @@ The following features are currently being released as part of a tech preview
 * New endpoint “pulp/api/v3/remotes/python/python/from_bandersnatch/” that allows for Python remote creation from a
   Bandersnatch config file.
 * PyPI’s json API at content endpoint ‘/pypi/{package-name}/json’. Allows for basic Pulp-to-Pulp syncing.
-* Fully mirror Python repositories like PyPI.
+* Fully mirror Python repositories provided PyPI and Pulp itself.
 * ``Twine`` upload packages to indexes at endpoints '/simple` or '/legacy'.
 * Create pull-through caches of remote sources.

--- a/template_config.yml
+++ b/template_config.yml
@@ -49,6 +49,7 @@ publish_docs_to_pulpprojectdotorg: true
 pulp_scheme: https
 pulp_settings:
   orphan_protection_time: 0
+  pypi_api_hostname: https://pulp:443
 pulpcore_branch: main
 pulpcore_pip_version_specifier: null
 pulpcore_revision: null


### PR DESCRIPTION
WIP syncing using simple page parsing. Implemented as a fallback for repositories that don't implement the PyPI XMLRPC endpoints (e.g. Pulp). Enables full Pulp to Pulp syncing.