### PR TITLE
Fix includes & excludes openapi schema

### DIFF
--- a/CHANGES/576.bugfix
+++ b/CHANGES/576.bugfix
@@ -1,0 +1,1 @@
+Changed includes and excludes openapi schema to report as array of strings instead of object.

--- a/pulp_python/app/serializers.py
+++ b/pulp_python/app/serializers.py
@@ -279,20 +279,21 @@ class PythonRemoteSerializer(core_serializers.RemoteSerializer):
     A Serializer for PythonRemote.
     """
 
-    includes = serializers.JSONField(
+    includes = serializers.ListField(
+        child=serializers.CharField(allow_blank=False),
         required=False,
-        default=list,
+        allow_empty=True,
         help_text=_(
-            "A JSON list containing project specifiers for Python packages to include."
+            "A list containing project specifiers for Python packages to include."
         ),
     )
-    excludes = serializers.JSONField(
+    excludes = serializers.ListField(
+        child=serializers.CharField(allow_blank=False),
         required=False,
-        default=list,
+        allow_empty=True,
         help_text=_(
-            "A JSON list containing project specifiers for Python packages to exclude."
+            "A list containing project specifiers for Python packages to exclude."
         ),
-
     )
     prereleases = serializers.BooleanField(
         required=False,

--- a/pulp_python/tests/functional/api/test_download_content.py
+++ b/pulp_python/tests/functional/api/test_download_content.py
@@ -124,7 +124,7 @@ class PublishPyPIJSON(TestCaseUsingBindings, TestHelpersMixin):
         This test checks that Pulp can fully sync another Python Package repository that is not
         PyPI. This reads the repository's simple page if XMLRPC isn't supported.
         """
-        remote = self._create_remote(includes="", prereleases=True)
+        remote = self._create_remote(includes=[], prereleases=True)
         repo = self._create_repo_and_sync_with_remote(remote)
         self.assertEqual(get_content_summary(repo.to_dict()), PYTHON_LG_FIXTURE_SUMMARY)
 
@@ -138,14 +138,14 @@ class PublishPyPIJSON(TestCaseUsingBindings, TestHelpersMixin):
         # Test using live generated simple pages
         distro = self._create_distribution_from_repo(repo)
 
-        remote = self._create_remote(includes="", url=distro.base_url)
+        remote = self._create_remote(includes=[], url=distro.base_url)
         repo2 = self._create_repo_and_sync_with_remote(remote)
         self.assertEqual(get_content_summary(repo2.to_dict()), PYTHON_MD_FIXTURE_SUMMARY)
 
         # Now test using publication simple pages
         pub = self._create_publication(repo)
         distro2 = self._create_distribution_from_publication(pub)
-        remote = self._create_remote(includes="", url=distro2.base_url, prereleases=True)
+        remote = self._create_remote(includes=[], url=distro2.base_url, prereleases=True)
 
         repo3 = self._create_repo_and_sync_with_remote(remote)
         self.assertEqual(get_content_summary(repo3.to_dict()), PYTHON_MD_FIXTURE_SUMMARY)


### PR DESCRIPTION
fixes: #576

This change can be backported (I think), would you like to see it in previous pulp_python versions?

I'll look into changing the underlying model in a future change (hopefully in a way that is compliant with the new zero downtime changes)

@mdellweg 