### PR TITLE
Fix duplicate operationID for simple PyPI endpoints

### DIFF
--- a/CHANGES/594.bugfix
+++ b/CHANGES/594.bugfix
@@ -1,0 +1,1 @@
+Fixed duplicate operationID for generated PyPI simple endpoints schema.

--- a/pulp_python/app/pypi/views.py
+++ b/pulp_python/app/pypi/views.py
@@ -214,7 +214,7 @@ class SimpleView(ViewSet, PackageUploadMixin):
         packages = (parse_url(link) for link in links)
         return StreamingHttpResponse(write_simple_detail(package, packages, streamed=True))
 
-    @extend_schema(summary="Get package simple page")
+    @extend_schema(operation_id="pypi_simple_package_read", summary="Get package simple page")
     def retrieve(self, request, path, package):
         """Retrieves the simple api html page for a package."""
         distro, repo_ver, content = self.get_drvc(path)


### PR DESCRIPTION
fixes: #594
@jlsherrill Do you want this back-ported to 3.7?
