### PR TITLE
Remove pin on client bindings from functest_requirements

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -18,6 +18,4 @@ values =
 
 [bumpversion:file:./setup.py]
 
-[bumpversion:file:./functest_requirements.txt]
-
 [bumpversion:file:./docs/conf.py]

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -4,4 +4,4 @@ lxml
 twine
 pypi-simple
 pulpcore-client
-pulp-python-client==3.10.0.dev
+pulp-python-client


### PR DESCRIPTION
This is breaking the release CI (not sure what changed there), but to move forward for now I am removing the pin.