### PR TITLE
Set SERVE_FROM_PUBLICATION on PythonDistribution

### DIFF
--- a/pulp_python/app/models.py
+++ b/pulp_python/app/models.py
@@ -52,6 +52,7 @@ class PythonDistribution(Distribution):
     """
 
     TYPE = "python"
+    SERVE_FROM_PUBLICATION = True
 
     allow_uploads = models.BooleanField(default=True)
 


### PR DESCRIPTION
I don't know if this is strictly required since pulp_python defines its own content handler function but SERVE_FROM_PUBLICATION ought to be set from a technical correctness standpoint. Also future work might expect it to be set such as the repo version protection PR I have open against pulpcore:

https://github.com/pulp/pulpcore/pull/4750