### PR TITLE
Remove bindings from functest requirements

### DIFF
--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -2,8 +2,6 @@ pytest<8
 lxml
 twine
 pypi-simple
-pulpcore-client
-pulp-python-client
 pytest-custom_exit_code
 pytest-xdist
 proxy.py~=2.4.4


### PR DESCRIPTION
Latest CI update is failing because the bindings seem to longer be required in `functest_requirements.txt`.