### PR TITLE
Fix upload not supporting package metadata 2.3

### DIFF
--- a/CHANGES/682.bugfix
+++ b/CHANGES/682.bugfix
@@ -1,0 +1,1 @@
+Fixed uploads not supporting packages using metadata spec 2.3

--- a/pulp_python/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_python/tests/functional/api/test_crud_content_unit.py
@@ -1,6 +1,7 @@
 import pytest
 
 from urllib.parse import urljoin
+from pypi_simple import PyPISimple
 
 from pulpcore.tests.functional.utils import PulpTaskError
 from pulp_python.tests.functional.constants import (
@@ -108,3 +109,16 @@ def test_content_crud(
         monitor_task(response.task)
     msg = "The uploaded artifact's sha256 checksum does not match the one provided"
     assert msg in e.value.task.error["description"]
+
+
+@pytest.mark.parallel
+def test_upload_metadata_23_spec(python_content_factory):
+    """Test that packages using metadata spec 2.3 can be uploaded to pulp."""
+    filename = "urllib3-2.2.2-py3-none-any.whl"
+    with PyPISimple() as client:
+        page = client.get_project_page("urllib3")
+        for package in page.packages:
+            if package.filename == filename:
+                content = python_content_factory(filename, url=package.url)
+                assert content.metadata_version == "2.3"
+                break

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pulpcore>=3.49.0,<3.70.0
-pkginfo>=1.8.2,<1.9.7
+pkginfo>=1.10.0,<1.12.0  # Twine has <1.11 in their requirements
 bandersnatch>=6.1,<6.2
 pypi-simple>=0.9.0,<1.0.0


### PR DESCRIPTION
fixes: #682

@dralley This should be safe to backport. And I'll complete full 2.3 support with #689 as a new feature for a future release.