### PR TITLE
Fix upload not supporting package metadata 2.3

### DIFF
--- a/CHANGES/682.bugfix
+++ b/CHANGES/682.bugfix
@@ -1,0 +1,1 @@
+Fixed uploads not supporting packages using metadata spec 2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pulpcore>=3.28,<3.55
-pkginfo>=1.8.2,<1.9.7
+pkginfo>=1.10.0,<1.12.0  # Twine has <1.11 in their requirements
 bandersnatch>=6.1,<6.2
 pypi-simple>=0.9.0,<1.0.0


### PR DESCRIPTION
fixes: #682
(cherry picked from commit 781b9767dae34e8619e3831ff8ad07de1a6222ec)