### PR TITLE
Backport #717 to 3.11

### DIFF
--- a/CHANGES/716.bugfix
+++ b/CHANGES/716.bugfix
@@ -1,0 +1,1 @@
+Fixed package name normalization issue preventing syncing packages with "." or "_" in their names.

--- a/pulp_python/app/pypi/views.py
+++ b/pulp_python/app/pypi/views.py
@@ -278,7 +278,8 @@ class MetadataView(ViewSet, PyPIMixin):
         elif meta_path.match("*/json"):
             name = meta_path.parts[0]
         if name:
-            package_content = content.filter(name__iexact=name)
+            normalized = canonicalize_name(name)
+            package_content = content.filter(name__normalize=normalized)
             # TODO Change this value to the Repo's serial value when implemented
             headers = {PYPI_LAST_SERIAL: str(PYPI_SERIAL_CONSTANT)}
             json_body = python_content_to_json(path, package_content, version=version)


### PR DESCRIPTION
Fix package name normalization for package pypi json view

(cherry picked from commit fc43b4b253dbec5931d6a230296942e4ba52ec3e)