### PR TITLE
Raise upperbound pkginfo requirement

### DIFF
--- a/CHANGES/+preliminary-md-24-support.misc
+++ b/CHANGES/+preliminary-md-24-support.misc
@@ -1,0 +1,1 @@
+Ensure uploading packages with metadata spec 2.4 is supported.

--- a/pulp_python/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_python/tests/functional/api/test_crud_content_unit.py
@@ -134,3 +134,16 @@ def test_upload_requires_python(python_content_factory):
                 content = python_content_factory(filename, url=package.url)
                 assert content.requires_python == ">=3.8"
                 break
+
+
+@pytest.mark.parallel
+def test_upload_metadata_24_spec(python_content_factory):
+    """Test that packages using metadata spec 2.4 can be uploaded to pulp."""
+    filename = "urllib3-2.3.0-py3-none-any.whl"
+    with PyPISimple() as client:
+        page = client.get_project_page("urllib3")
+        for package in page.packages:
+            if package.filename == filename:
+                content = python_content_factory(filename, url=package.url)
+                assert content.metadata_version == "2.4"
+                break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers=[
 requires-python = ">=3.9"
 dependencies = [
   "pulpcore>=3.49.0,<3.85",
-  "pkginfo>=1.10.0,<1.12.0",  # Twine has <1.11 in their requirements
+  "pkginfo>=1.10.0,<1.13.0",
   "bandersnatch>=6.3,<7.0",  # Anything >6.3 requires Python 3.10+
   "pypi-simple>=1.5.0,<2.0",
 ]


### PR DESCRIPTION
Twine no longer uses pkginfo, so we no longer need to prevent installing the latest. This will also mean that Metadata 2.4 packages will no longer break on upload.