### PR TITLE
Pin bandersnatch to <6.6.

### DIFF
--- a/CHANGES/809.misc
+++ b/CHANGES/809.misc
@@ -1,0 +1,1 @@
+Pin bandersnatch due to backwards-incompatible change in 6.6.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.9"
 dependencies = [
   "pulpcore>=3.49.0,<3.85",
   "pkginfo>=1.10.0,<1.13.0",
-  "bandersnatch>=6.3,<7.0",  # Anything >6.3 requires Python 3.10+
+  "bandersnatch>=6.3.0,<6.4",  # Anything >6.3 requires Python 3.10+
   "pypi-simple>=1.5.0,<2.0",
 ]
 


### PR DESCRIPTION
See https://github.com/pypa/bandersnatch/issues/1892 for the discussion.