### PR TITLE
Fix proxy-sync regression

### DIFF
--- a/CHANGES/+proxy-sync-regression-313.bugfix
+++ b/CHANGES/+proxy-sync-regression-313.bugfix
@@ -1,0 +1,1 @@
+Fixed a proxy sync regression introduced in 3.13.0.


### PR DESCRIPTION
Not sure how to properly test this. The big problem is that bandersnatch creates their own aiohttp session in order to download metadata and the packages. I thought by replacing their session with the remote's session (https://github.com/pulp/pulp_python/pull/750) we would get all of the remote's options by default, but I didn't realize that the auth & proxy settings are actually set at download time in the Downloader's `_run` method (https://github.com/pulp/pulpcore/blob/main/pulpcore/download/http.py#L292-L294). This should fix the regression by patching the `get` method that bandersnatch's `Master` class uses to perform requests, but there is no way for me to test it with our current fixtures. The `http_proxy` fixture doesn't give access to the proxy's request logs, just the data used to setup the proxy.