### PR TITLE
Fix deprecated license classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 authors = [
   {name="Pulp Team", email="pulp-list@redhat.com"},
 ]
+license = "GPL-2.0-or-later"
 classifiers=[
-  "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
   "Operating System :: POSIX :: Linux",
   "Development Status :: 5 - Production/Stable",
   "Framework :: Django",


### PR DESCRIPTION
This PR replaces the deprecated license classifiers with an SPDX license expression. See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.