### PR TITLE
Fix pull-through caching for indexes with relative urls

### DIFF
--- a/CHANGES/842.bugfix
+++ b/CHANGES/842.bugfix
@@ -1,0 +1,1 @@
+Fixed pull-through caching not working for indexes that use relative URLs.

--- a/pulp_python/app/pypi/views.py
+++ b/pulp_python/app/pypi/views.py
@@ -260,9 +260,9 @@ class SimpleView(PackageUploadMixin, ViewSet):
             return HttpResponse(f"{remote.url} timed out while fetching {package}.", status=504)
 
         if d.headers["content-type"] == "application/vnd.pypi.simple.v1+json":
-            page = ProjectPage.from_json_data(json.load(open(d.path, "rb")), base_url=remote.url)
+            page = ProjectPage.from_json_data(json.load(open(d.path, "rb")), base_url=url)
         else:
-            page = ProjectPage.from_html(package, open(d.path, "rb").read(), base_url=remote.url)
+            page = ProjectPage.from_html(package, open(d.path, "rb").read(), base_url=url)
         packages = [
             parse_package(p) for p in page.packages if rfilter.filter_release(package, p.version)
         ]


### PR DESCRIPTION
fixes: #842

@MichelPoppema Was this the fix you tested?