### PR TITLE
Fix bandersnatch version note in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.9"
 dependencies = [
   "pulpcore>=3.49.0,<3.85",
   "pkginfo>=1.10.0,<1.13.0",
-  "bandersnatch>=6.3.0,<6.4",  # Anything >6.3 requires Python 3.10+
+  "bandersnatch>=6.3.0,<6.4",  # Anything >=6.4 requires Python 3.10+
   "pypi-simple>=1.5.0,<2.0",
 ]
 


### PR DESCRIPTION
This PR fixes the bandersnatch version note in `pyproject.toml` to correctly describe the upper version limit.