### PR TITLE
Add 3.10 and 3.13 to supported branches

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -78,6 +78,37 @@ jobs:
         with:
           fetch-depth: 0
           path: "pulp_python"
+          ref: "3.10"
+
+      - name: "Run update"
+        working-directory: "pulp_python"
+        run: |
+          ../plugin_template/scripts/update_ci.sh --release
+
+      - name: "Create Pull Request for CI files"
+        uses: "peter-evans/create-pull-request@v6"
+        id: "create_pr_3_10"
+        with:
+          token: "${{ secrets.RELEASE_TOKEN }}"
+          path: "pulp_python"
+          committer: "pulpbot <pulp-infra@redhat.com>"
+          author: "pulpbot <pulp-infra@redhat.com>"
+          title: "Update CI files for branch 3.10"
+          branch: "update-ci/3.10"
+          base: "3.10"
+          delete-branch: true
+      - name: "Mark PR automerge"
+        working-directory: "pulp_python"
+        run: |
+          gh pr merge --rebase --auto "${{ steps.create_pr_3_10.outputs.pull-request-number }}"
+        if: "steps.create_pr_3_10.outputs.pull-request-number"
+        env:
+          GH_TOKEN: "${{ secrets.RELEASE_TOKEN }}"
+        continue-on-error: true
+      - uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+          path: "pulp_python"
           ref: "3.11"
 
       - name: "Run update"
@@ -133,6 +164,37 @@ jobs:
         run: |
           gh pr merge --rebase --auto "${{ steps.create_pr_3_12.outputs.pull-request-number }}"
         if: "steps.create_pr_3_12.outputs.pull-request-number"
+        env:
+          GH_TOKEN: "${{ secrets.RELEASE_TOKEN }}"
+        continue-on-error: true
+      - uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+          path: "pulp_python"
+          ref: "3.13"
+
+      - name: "Run update"
+        working-directory: "pulp_python"
+        run: |
+          ../plugin_template/scripts/update_ci.sh --release
+
+      - name: "Create Pull Request for CI files"
+        uses: "peter-evans/create-pull-request@v6"
+        id: "create_pr_3_13"
+        with:
+          token: "${{ secrets.RELEASE_TOKEN }}"
+          path: "pulp_python"
+          committer: "pulpbot <pulp-infra@redhat.com>"
+          author: "pulpbot <pulp-infra@redhat.com>"
+          title: "Update CI files for branch 3.13"
+          branch: "update-ci/3.13"
+          base: "3.13"
+          delete-branch: true
+      - name: "Mark PR automerge"
+        working-directory: "pulp_python"
+        run: |
+          gh pr merge --rebase --auto "${{ steps.create_pr_3_13.outputs.pull-request-number }}"
+        if: "steps.create_pr_3_13.outputs.pull-request-number"
         env:
           GH_TOKEN: "${{ secrets.RELEASE_TOKEN }}"
         continue-on-error: true

--- a/template_config.yml
+++ b/template_config.yml
@@ -59,8 +59,10 @@ stalebot_days_until_close: 30
 stalebot_days_until_stale: 90
 stalebot_limit_to_pulls: true
 supported_release_branches:
+- '3.10'
 - '3.11'
 - '3.12'
+- '3.13'
 sync_ci: true
 test_azure: true
 test_cli: true


### PR DESCRIPTION
This PR adds pulp_python 3.10 and 3.13 to supported branches, since Katello uses 3.10 for their pulpcore 3.28 and 3.39 branches, and 3.13 for the pulpcore 3.73 branch.