### PR TITLE
[PR #692/a37d040b backport][3.10] Fix package_types filter breaking others

### DIFF
--- a/CHANGES/691.bugfix
+++ b/CHANGES/691.bugfix
@@ -1,0 +1,1 @@
+Fixed the `package_types` filter breaking other remote filters.

--- a/pulp_python/app/tasks/sync.py
+++ b/pulp_python/app/tasks/sync.py
@@ -80,7 +80,7 @@ def create_bandersnatch_config(remote):
         config["plugins"]["enabled"] += "prerelease_release\n"
     if remote.package_types:
         rrfm = "regex_release_file_metadata"
-        config["plugins"]["enabled"] += rrfm
+        config["plugins"]["enabled"] += f"{rrfm}\n"
         if not config.has_section(rrfm):
             config.add_section(rrfm)
         config[rrfm]["any:release_file.packagetype"] = "\n".join(remote.package_types)

--- a/pulp_python/tests/functional/api/test_sync.py
+++ b/pulp_python/tests/functional/api/test_sync.py
@@ -642,6 +642,23 @@ class PlatformExcludeTestCase(unittest.TestCase):
 
 
 @pytest.mark.parallel
+def test_sync_multiple_filters(
+    python_repo_with_sync, python_remote_factory, python_content_summary
+):
+    """Tests sync with multiple filters."""
+    remote = python_remote_factory(
+        includes=PYTHON_LG_PROJECT_SPECIFIER,
+        package_types=["bdist_wheel"],
+        keep_latest_packages=1,
+        prereleases=False
+    )
+    repo = python_repo_with_sync(remote)
+
+    summary = python_content_summary(repository_version=repo.latest_version_href)
+    assert summary.present["python.python"]["count"] == PYTHON_LG_FIXTURE_COUNTS["multi"]
+
+
+@pytest.mark.parallel
 def test_proxy_sync(
     python_repo,
     python_repo_api_client,

--- a/pulp_python/tests/functional/conftest.py
+++ b/pulp_python/tests/functional/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import uuid
 
 from pulp_smash.pulp3.utils import gen_distribution, gen_repo
 from pulp_python.tests.functional.utils import gen_python_remote
@@ -9,6 +10,7 @@ from pulpcore.client.pulp_python import (
     DistributionsPypiApi,
     PublicationsPypiApi,
     RepositoriesPythonApi,
+    RepositoriesPythonVersionsApi,
     RemotesPythonApi,
 )
 
@@ -27,6 +29,12 @@ def python_bindings_client(cid, bindings_cfg):
 def python_repo_api_client(python_bindings_client):
     """Provides the Python Repository API client object."""
     return RepositoriesPythonApi(python_bindings_client)
+
+
+@pytest.fixture
+def python_repo_version_api_client(python_bindings_client):
+    """Provides the Python Repository Version API client object."""
+    return RepositoriesPythonVersionsApi(python_bindings_client)
 
 
 @pytest.fixture
@@ -54,6 +62,16 @@ def python_publication_api_client(python_bindings_client):
 
 
 # Object Generation Fixtures
+
+@pytest.fixture
+def python_repo_factory(python_repo_api_client, gen_object_with_cleanup):
+    """A factory to generate a Python Repository with auto-cleanup."""
+    def _gen_python_repo(**kwargs):
+        kwargs.setdefault("name", str(uuid.uuid4()))
+        return gen_object_with_cleanup(python_repo_api_client, kwargs)
+
+    return _gen_python_repo
+
 
 @pytest.fixture
 def python_repo(python_repo_api_client, gen_object_with_cleanup):
@@ -92,3 +110,43 @@ def python_remote_factory(python_remote_api_client, gen_object_with_cleanup):
         return gen_object_with_cleanup(python_remote_api_client, body)
 
     yield _gen_python_remote
+
+
+@pytest.fixture
+def python_repo_with_sync(
+    python_repo_api_client, python_repo_factory, python_remote_factory, monitor_task
+):
+    """A factory to generate a Python Repository synced with the passed in Remote."""
+    def _gen_python_repo_sync(remote=None, mirror=False, repository=None, **body):
+        kwargs = {}
+        if pulp_domain := body.get("pulp_domain"):
+            kwargs["pulp_domain"] = pulp_domain
+        remote = remote or python_remote_factory(**kwargs)
+        repo = repository or python_repo_factory(**body)
+        sync_body = {"mirror": mirror, "remote": remote.pulp_href}
+        monitor_task(python_repo_api_client.sync(repo.pulp_href, sync_body).task)
+        return python_repo_api_client.read(repo.pulp_href)
+
+    yield _gen_python_repo_sync
+
+
+@pytest.fixture
+def python_content_summary(python_repo_api_client, python_repo_version_api_client):
+    """Get a summary of the repository version's content."""
+    def _gen_summary(repository_version=None, repository=None, version=None):
+        if repository_version is None:
+            repo_href = get_href(repository)
+            if version:
+                repo_ver_href = f"{repo_href}versions/{version}/"
+            else:
+                repo_ver_href = python_repo_api_client.read(repo_href).latest_version_href
+        else:
+            repo_ver_href = get_href(repository_version)
+        return python_repo_version_api_client.read(repo_ver_href).content_summary
+
+    yield _gen_summary
+
+
+def get_href(item):
+    """Tries to get the href from the given item, whether it is a string or object."""
+    return item if isinstance(item, str) else item.pulp_href

--- a/pulp_python/tests/functional/constants.py
+++ b/pulp_python/tests/functional/constants.py
@@ -155,6 +155,7 @@ PYTHON_LG_FIXTURE_COUNTS = {
     "latest_3": 37,
     "sdist": 24,
     "bdist_wheel": 54,
+    "multi": 26,  # keep_latest=1, package_types="bdist_wheel", prereleases=False
 }
 
 DJANGO_LATEST_3 = 4  # latest version has 2 dists, each other has 1


### PR DESCRIPTION
This is a manually updated backport of PR #692, based on commit [a37d040](https://github.com/pulp/pulp_python/commit/a37d040b901d70a527c208fab9edef486039a205) from main.