### PR TITLE
Remove changelog entry that does not impact users

### DIFF
--- a/CHANGES/876.bugfix
+++ b/CHANGES/876.bugfix
@@ -1,1 +1,0 @@
-Fixed tests to account for new fixtures.


### PR DESCRIPTION
This PR removes the changelog entry about test fixes, as the change does not impact users and therefore should not be included.

Related to #877