### PR TITLE
Backport removal of twine --skip-existing test [3.11]

### DIFF
--- a/pulp_python/tests/functional/api/test_pypi_apis.py
+++ b/pulp_python/tests/functional/api/test_pypi_apis.py
@@ -243,26 +243,6 @@ def test_twine_upload(
             check=True,
         )
 
-    # Test re-uploading same packages with --skip-existing works
-    output = subprocess.run(
-        (
-            "twine",
-            "upload",
-            "--repository-url",
-            url,
-            dist_dir / "*",
-            "-u",
-            username,
-            "-p",
-            password,
-            "--skip-existing",
-        ),
-        capture_output=True,
-        check=True,
-        text=True
-    )
-    assert output.stdout.count("Skipping") == 2
-
 
 class PyPISimpleApi(TestCaseUsingBindings, TestHelpersMixin):
     """Tests that the simple api is correct."""


### PR DESCRIPTION
Remove testing of twine's --skip-existing due to twine feature removal

(cherry picked from commit 2b34643299835462a4add6b3b76d2d8309bf91d9)