### PR TITLE
Backport Remove testing of twine's --skip-existing due to twine feature removal [3.13]

### DIFF
--- a/pulp_python/tests/functional/api/test_pypi_apis.py
+++ b/pulp_python/tests/functional/api/test_pypi_apis.py
@@ -224,26 +224,6 @@ def test_twine_upload(
             check=True,
         )
 
-    # Test re-uploading same packages with --skip-existing works
-    output = subprocess.run(
-        (
-            "twine",
-            "upload",
-            "--repository-url",
-            url,
-            dist_dir / "*",
-            "-u",
-            username,
-            "-p",
-            password,
-            "--skip-existing",
-        ),
-        capture_output=True,
-        check=True,
-        text=True
-    )
-    assert output.stdout.count("Skipping") == 2
-
 
 @pytest.mark.parallel
 def test_simple_redirect_with_publications(


### PR DESCRIPTION
(cherry picked from commit 2b34643299835462a4add6b3b76d2d8309bf91d9)