### PR TITLE
Fix Azure Azurite API version compatibility error

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -152,7 +152,7 @@ echo ::endgroup::
 
 if [[ "$TEST" = "azure" ]]; then
   AZURE_STORAGE_CONNECTION_STRING='DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://ci-azurite:10000/devstoreaccount1;'
-  az storage container create --name pulp-test --connection-string $AZURE_STORAGE_CONNECTION_STRING
+  az storage container create --name pulp-test --connection-string $AZURE_STORAGE_CONNECTION_STRING --skipApiVersionCheck
 fi
 
 echo ::group::PIP_LIST


### PR DESCRIPTION
Add --skipApiVersionCheck flag to the Azure storage container creation command to prevent API version
mismatch errors with Azurite in CI.
Resolves the 'API version 2026-02-06
is not supported by Azurite' error present in nightly release