### PR TITLE
Add the contains filter for the name and author fields in the python content endpoint.

### DIFF
--- a/CHANGES/1096.feature
+++ b/CHANGES/1096.feature
@@ -1,0 +1,1 @@
+Added the `contains` filter to `name` and `author` fields for the Content endpoint.

--- a/pulp_python/app/viewsets.py
+++ b/pulp_python/app/viewsets.py
@@ -337,8 +337,8 @@ class PythonPackageContentFilter(core_viewsets.ContentFilter):
     class Meta:
         model = python_models.PythonPackageContent
         fields = {
-            "name": ["exact", "in"],
-            "author": ["exact", "in"],
+            "name": ["exact", "in", "contains"],
+            "author": ["exact", "in", "contains"],
             "packagetype": ["exact", "in"],
             "requires_python": ["exact", "in", "contains"],
             "filename": ["exact", "in", "contains"],


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

This PR adds a `contains` filter to `name` and `author` fields for the Content endpoint.

Closes #1096

### 📜 Checklist

- [X] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [X] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [X] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [X] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
