### PR TITLE
Remove unneeded serializer field

### DIFF
--- a/CHANGES/+remove-serializer-fields.misc
+++ b/CHANGES/+remove-serializer-fields.misc
@@ -1,0 +1,1 @@
+Pulpcore enabled a feature to allow users to specify "repository_version" on their distributions, which pulp_python already allowed. We no longer need to enable that field ourselves.

--- a/pulp_python/app/serializers.py
+++ b/pulp_python/app/serializers.py
@@ -74,9 +74,6 @@ class PythonDistributionSerializer(core_serializers.DistributionSerializer):
         queryset=core_models.Publication.objects.exclude(complete=False),
         allow_null=True,
     )
-    repository_version = core_serializers.RepositoryVersionRelatedField(
-        required=False, help_text=_("RepositoryVersion to be served."), allow_null=True
-    )
     base_url = serializers.SerializerMethodField(read_only=True)
     allow_uploads = serializers.BooleanField(
         default=True, help_text=_("Allow packages to be uploaded to this index.")
@@ -98,7 +95,6 @@ class PythonDistributionSerializer(core_serializers.DistributionSerializer):
     class Meta:
         fields = core_serializers.DistributionSerializer.Meta.fields + (
             "publication",
-            "repository_version",
             "allow_uploads",
             "remote",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers=[
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "pulpcore>=3.85.3,<3.115",
+  "pulpcore>=3.106.0,<3.115",
   "pkginfo>=1.12.0,<1.13.0",
   "bandersnatch>=6.6.0,<6.7",
   "pypi-simple>=1.8.0,<2.0",


### PR DESCRIPTION
And adapt to the possibility that the user may want to distribute a particular repository version, perhaps without having created a publication.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
