### PR TITLE
[PULP-1646] Deprecate repair-python-metadata command

### DIFF
--- a/CHANGES/1207.removal
+++ b/CHANGES/1207.removal
@@ -1,0 +1,1 @@
+Deprecated the `repair-python-metadata` management command in favor of the repository `repair_metadata` task.

--- a/pulp_python/app/management/commands/repair-python-metadata.py
+++ b/pulp_python/app/management/commands/repair-python-metadata.py
@@ -78,7 +78,10 @@ class Command(BaseCommand):
     Management command to repair metadata of PythonPackageContent.
     """
 
-    help = _("Repair the metadata of PythonPackageContent stored in PythonRepositories")
+    help = _(
+        "[Deprecated] Use the repository `repair_metadata` task instead. "
+        "Repair the metadata of PythonPackageContent stored in PythonRepositories."
+    )
 
     def add_arguments(self, parser):
         """Set up arguments."""


### PR DESCRIPTION
closes #1207

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
