### PR TITLE
[PULP-1694] [3.19] Fix pull-through caching failing for improper named packages

### DIFF
--- a/CHANGES/1040.bugfix
+++ b/CHANGES/1040.bugfix
@@ -1,0 +1,1 @@
+Fixed pull-through caching failing for packages with bad names.

--- a/pulp_python/app/utils.py
+++ b/pulp_python/app/utils.py
@@ -458,7 +458,7 @@ class PackageIncludeFilter:
 
         try:
             version = parse(version)
-        except InvalidVersion:
+        except (InvalidVersion, TypeError):
             return False
 
         include_range = self._filter_includes.get("range", {})

--- a/pulp_python/tests/functional/api/test_full_mirror.py
+++ b/pulp_python/tests/functional/api/test_full_mirror.py
@@ -164,3 +164,23 @@ def test_pull_through_local_only(
     r = requests.get(url)
     assert r.status_code == 404
     assert r.text == "pulp-python does not exist."
+
+
+@pytest.mark.parallel
+def test_pull_through_filtering_bad_names(python_remote_factory, python_distribution_factory):
+    """Tests that pull-through handles packages with invalid names gracefully."""
+    # ipython version 0.13.X has improper named bdist_wininst, e.g ipython-0.13.py2-win-amd64.exe
+    # pypi-simple expects the platform to go before the pyversion (for .exe), so when parsed the
+    # version and package type will be None.
+    remote = python_remote_factory(url=PYPI_URL, includes=["ipython"])
+    distro = python_distribution_factory(remote=remote.pulp_href)
+
+    url = f"{distro.base_url}simple/ipython/"
+    response = requests.get(url)
+
+    assert response.status_code == 200
+
+    project_page = ProjectPage.from_response(response, "ipython")
+    # Should have no packages with None version (they get filtered out)
+    assert len(project_page.packages) > 0
+    assert all(package.version is not None for package in project_page.packages)


### PR DESCRIPTION
Manual backport of #1084

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
