### PR TITLE
[PR #1263/5f7586d7 backport][3.13] Fix python_version parsing for workers with hyphens in their hostname

### DIFF
--- a/CHANGES/+py-version-parsing.bugfix
+++ b/CHANGES/+py-version-parsing.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where the `python_version` field was not parsed correctly when Pulp workers had hyphens in their name.

--- a/pulp_python/app/utils.py
+++ b/pulp_python/app/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import shutil
 import tempfile
@@ -173,7 +174,7 @@ def get_project_metadata_from_artifact(filename, artifact):
         else:
             pyver = ""
             regex = DIST_REGEXES[extensions[pkg_type_index]]
-            if bdist_name := regex.match(filename):
+            if bdist_name := regex.match(os.path.basename(filename)):
                 pyver = bdist_name.group("pyver") or ""
             metadata.python_version = pyver
         return metadata


### PR DESCRIPTION
**This is a backport of PR #1263 as merged into main (5f7586d701624c61988bf71f0e2a3e4ee8b0a40a).**

Patchback failed to cherry-pick due to conflicts — the 3.13 branch uses `get_project_metadata_from_artifact` instead of `get_project_metadata_from_file`, so the equivalent fix was applied manually.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)

## Test plan

- [ ] CI passes on the 3.13 branch


Made with [Cursor](https://cursor.com)