### PR TITLE
Fix provenance sync for Pulp User publishers

### DIFF
--- a/CHANGES/+pulp-attestation-sync.bugfix
+++ b/CHANGES/+pulp-attestation-sync.bugfix
@@ -1,0 +1,1 @@
+Fixed provenance sync failing when syncing Pulp-created attestations that use a `Pulp User` publisher.

--- a/pulp_python/app/tasks/sync.py
+++ b/pulp_python/app/tasks/sync.py
@@ -9,7 +9,6 @@ from bandersnatch.master import Master
 from bandersnatch.mirror import Mirror
 from lxml.etree import LxmlError
 from packaging.requirements import Requirement
-from pypi_attestations import Provenance
 from pypi_simple import IndexPage
 
 from pulpcore.plugin.download import HttpDownloader
@@ -28,6 +27,7 @@ from pulp_python.app.models import (
     PythonPackageContent,
     PythonRemote,
 )
+from pulp_python.app.provenance import Provenance
 from pulp_python.app.utils import PYPI_LAST_SERIAL, aget_remote_simple_page, parse_metadata
 
 logger = logging.getLogger(__name__)

--- a/pulp_python/tests/functional/api/test_attestations.py
+++ b/pulp_python/tests/functional/api/test_attestations.py
@@ -8,7 +8,6 @@ import pytest
 import requests
 from pypi_simple import PyPISimple
 
-from pulpcore.app import settings  # noqa: TID251
 from pulpcore.tests.functional.utils import PulpTaskError
 
 
@@ -155,7 +154,6 @@ def test_attestation_sync_upload(python_bindings, twine_package, download_python
     assert att_bundle["publisher"]["kind"] == "Pulp User"
 
 
-@pytest.mark.skipif(not settings.DOMAIN_ENABLED, reason="Domain not enabled")
 @pytest.mark.parallel
 def test_sync_pulp_created_provenance(
     domain_factory,

--- a/pulp_python/tests/functional/api/test_attestations.py
+++ b/pulp_python/tests/functional/api/test_attestations.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 from pypi_simple import PyPISimple
 
+from pulpcore.app import settings  # noqa: TID251
 from pulpcore.tests.functional.utils import PulpTaskError
 
 
@@ -152,6 +153,55 @@ def test_attestation_sync_upload(python_bindings, twine_package, download_python
     att_bundle = prov.provenance["attestation_bundles"][0]
     assert att_bundle["attestations"] == attestations
     assert att_bundle["publisher"]["kind"] == "Pulp User"
+
+
+@pytest.mark.skipif(not settings.DOMAIN_ENABLED, reason="Domain not enabled")
+@pytest.mark.parallel
+def test_sync_pulp_created_provenance(
+    domain_factory,
+    python_bindings,
+    twine_package,
+    python_repo_factory,
+    python_distribution_factory,
+    python_remote_factory,
+    python_repo_with_sync,
+    python_content_summary,
+    monitor_task,
+):
+    """Test syncing provenance across domains from a Pulp upload."""
+    source_domain = domain_factory()
+    attestations = get_attestations(twine_package.provenance_url)
+    source_repo = python_repo_factory(pulp_domain=source_domain.name)
+    body = {
+        "relative_path": twine_package.filename,
+        "file_url": twine_package.url,
+        "attestations": json.dumps(attestations),
+        "repository": source_repo.pulp_href,
+    }
+    task = python_bindings.ContentPackagesApi.create(pulp_domain=source_domain.name, **body).task
+    monitor_task(task)
+
+    source_distro = python_distribution_factory(
+        repository=source_repo, pulp_domain=source_domain.name
+    )
+    dest_domain = domain_factory()
+    remote = python_remote_factory(
+        url=source_distro.base_url,
+        provenance=True,
+        includes=[f"twine=={twine_package.version}"],
+        pulp_domain=dest_domain.name,
+    )
+    dest_repo = python_repo_with_sync(remote=remote, pulp_domain=dest_domain.name)
+
+    summary = python_content_summary(repository_version=dest_repo.latest_version_href)
+    assert summary.present["python.provenance"]["count"] == 1
+
+    provs = python_bindings.ContentProvenanceApi.list(
+        repository_version=dest_repo.latest_version_href,
+        pulp_domain=dest_domain.name,
+    )
+    assert provs.count == 1
+    assert provs.results[0].provenance["attestation_bundles"][0]["publisher"]["kind"] == "Pulp User"
 
 
 def test_attestation_twine_upload(


### PR DESCRIPTION
## Summary
- Import `Provenance` from `pulp_python.app.provenance` in the sync task instead of `pypi_attestations`, so sync accepts attestations with `Pulp User` publishers created during upload
- Add a functional test that uploads attestations to one repository and syncs provenance from that distribution into another

## Test plan
- [x] Added `test_sync_pulp_created_provenance` functional test
- [ ] `oci-env test functional -p python pulp_python/tests/functional/api/test_attestations.py::test_sync_pulp_created_provenance -v`

Assisted-by: Cursor

Made with [Cursor](https://cursor.com)