### PR TITLE
Run package substitution tests outside the parallel suite

### DIFF
--- a/pulp_python/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_python/tests/functional/api/test_crud_content_unit.py
@@ -203,7 +203,6 @@ def test_package_creation_with_metadata(
     )
 
 
-@pytest.mark.parallel
 def test_disallow_package_substitution(
     monitor_task,
     python_bindings,
@@ -272,7 +271,6 @@ def test_disallow_package_substitution(
     assert repo.latest_version_href.endswith("/2/")
 
 
-@pytest.mark.parallel
 def test_package_substitution_allowed_by_default(
     monitor_task,
     python_bindings,


### PR DESCRIPTION
## Summary
- Remove `@pytest.mark.parallel` from `test_disallow_package_substitution` and `test_package_substitution_allowed_by_default`
- These tests upload a different artifact under the `shelf-reader-0.1.tar.gz` filename, leaving incorrect global content that breaks parallel PyPI JSON checks (e.g. `test_pypi_json`)

## Test plan
- [ ] CI passes on `test (pulp)` without `test_pypi_json` digest mismatches
- [ ] Substitution tests still pass in the non-parallel phase


Made with [Cursor](https://cursor.com)