### PR TITLE
Remove pypi_json tests from paralell run

### DIFF
--- a/pulp_python/tests/functional/api/test_pypi_apis.py
+++ b/pulp_python/tests/functional/api/test_pypi_apis.py
@@ -245,8 +245,9 @@ def test_simple_redirect_with_publications(
     assert response.url == str(urljoin(pulp_content_url, f"{distro.base_path}/simple/"))
 
 
-@pytest.mark.parallel
-def test_pypi_json(python_remote_factory, python_repo_with_sync, python_distribution_factory):
+def test_pypi_json(
+    delete_orphans_pre, python_remote_factory, python_repo_with_sync, python_distribution_factory
+):
     """Checks the data of `pypi/{package_name}/json` endpoint."""
     remote = python_remote_factory(policy="immediate")
     repo = python_repo_with_sync(remote)
@@ -260,8 +261,8 @@ def test_pypi_json(python_remote_factory, python_repo_with_sync, python_distribu
     assert_pypi_json(response.json())
 
 
-@pytest.mark.parallel
 def test_pypi_json_content_app(
+    delete_orphans_pre,
     python_remote_factory,
     python_repo_with_sync,
     python_publication_factory,


### PR DESCRIPTION
Follow-up to #1274

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
