### PR TITLE
Switch content 2.4 metadata upload test to use attrs package to avoid race condition with large sync test

### DIFF
--- a/pulp_python/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_python/tests/functional/api/test_crud_content_unit.py
@@ -174,8 +174,8 @@ def test_upload_requires_python(python_content_factory):
 @pytest.mark.parallel
 def test_upload_metadata_24_spec(python_content_factory):
     """Test that packages using metadata spec 2.4 can be uploaded to pulp."""
-    filename = "setuptools-80.9.0.tar.gz"
-    url = get_package_url("setuptools", filename)
+    filename = "attrs-26.1.0.tar.gz"
+    url = get_package_url("attrs", filename)
     content = python_content_factory(filename, url=url)
     assert content.metadata_version == "2.4"
     assert content.license_expression == "MIT"


### PR DESCRIPTION
test_basic_pulp_to_pulp_sync uses the large python fixture to populate Pulp which includes setuptools. On sync we don't populate the metadata_version field since it isn't exposed in the pypi/json api, so if this test runs first then setuptools will not have the field set when the content is reused on the upload test. We should come up with a better long term solution but for now this should work.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
