### PR TITLE
[PR #1310/c7fa1454 backport][3.19] Switch content 2.4 metadata upload test to use attrs package to avoid race condition with large sync test

### DIFF
--- a/pulp_python/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_python/tests/functional/api/test_crud_content_unit.py
@@ -170,9 +170,9 @@ def test_upload_requires_python(python_content_factory):
 @pytest.mark.parallel
 def test_upload_metadata_24_spec(python_content_factory):
     """Test that packages using metadata spec 2.4 can be uploaded to pulp."""
-    filename = "setuptools-80.9.0.tar.gz"
+    filename = "attrs-26.1.0.tar.gz"
     with PyPISimple() as client:
-        page = client.get_project_page("setuptools")
+        page = client.get_project_page("attrs")
         for package in page.packages:
             if package.filename == filename:
                 content = python_content_factory(filename, url=package.url)


### PR DESCRIPTION
**This is a backport of PR #1310 as merged into main (c7fa1454ac6d806502bfe46be676ef73c50369a0).**

Cherry-pick conflict resolved manually: kept the `PyPISimple` lookup style used on 3.19 while switching the package from `setuptools` to `attrs`.

test_basic_pulp_to_pulp_sync uses the large python fixture to populate Pulp which includes setuptools. On sync we don't populate the metadata_version field since it isn't exposed in the pypi/json api, so if this test runs first then setuptools will not have the field set when the content is reused on the upload test. We should come up with a better long term solution but for now this should work.

Made with [Cursor](https://cursor.com)