### PR TITLE
Use safe dict access for yanked fields

### DIFF
--- a/pulp_python/app/utils.py
+++ b/pulp_python/app/utils.py
@@ -607,9 +607,9 @@ def write_simple_detail_json(project_name, project_packages):
                 ),
                 # PEP 592
                 "yanked": (
-                    package["yanked_reason"]
-                    if package["yanked"] and package["yanked_reason"]
-                    else package["yanked"]
+                    package.get("yanked_reason")
+                    if package.get("yanked") and package.get("yanked_reason")
+                    else package.get("yanked", False)
                 ),
                 # (v1.1, PEP 700)
                 "size": package["size"],


### PR DESCRIPTION
Follow-up to #1282

This is needed to avoid a `KeyError` at runtime for pulp-service, whose patch [0060](https://github.com/pulp/pulp-service/blob/main/images/assets/patches/0060-Add-content_handler_json-to-PythonDistribution.patch) passes release dicts to `write_simple_detail_json` without `yanked` and `yanked_reason` keys.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
