### PR TITLE
Fix http error reporting and json metadata handling

### DIFF
--- a/CHANGES/+fixed-error-reporting-and-json-metadata-handling.bugfix
+++ b/CHANGES/+fixed-error-reporting-and-json-metadata-handling.bugfix
@@ -1,0 +1,1 @@
+Fixed python syncs masking HTTP errors as stale metadata and handling native json list values in package metadata

--- a/pulp_python/app/tasks/sync.py
+++ b/pulp_python/app/tasks/sync.py
@@ -130,6 +130,7 @@ class PythonBanderStage(Stage):
                 auth=downloader.auth,
                 proxy=downloader.proxy,
                 proxy_auth=downloader.proxy_auth,
+                raise_for_status=True,
             )
 
             deferred_download = self.remote.policy != Remote.IMMEDIATE

--- a/pulp_python/app/utils.py
+++ b/pulp_python/app/utils.py
@@ -441,7 +441,7 @@ def json_to_dict(data):
         dictionary: of JSON string
 
     """
-    if isinstance(data, dict):
+    if isinstance(data, (dict, list)):
         return data
 
     return json.loads(data)


### PR DESCRIPTION
Bandersnatch masks http errors when syncing packages as stale metadata instead of reporting them directly the `raise_for_status` flag will show the actual error like if the package is not here 404, or there is a server side error 5xx. This helps debugging. It also doesn't run into a retry loop but fails fast.

The other change allows native json list values to be allowed when rendering python package metadata, an error that previously was masked as stale metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Python synchronization now reports HTTP errors accurately instead of misclassifying them as stale metadata.
  * Package metadata containing native JSON lists is now handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->